### PR TITLE
Fix type annotations

### DIFF
--- a/dodona_command.py
+++ b/dodona_command.py
@@ -5,7 +5,7 @@ import sys
 from abc import ABC
 from enum import Enum
 from types import SimpleNamespace, TracebackType
-from typing import Union
+from typing import Dict, Type, Union
 
 
 class ErrorType(str, Enum):
@@ -79,7 +79,7 @@ class DodonaException(Exception):
 
     def __init__(
         self,
-        status: dict[str, str],
+        status: Dict[str, str],
         *args,
         **kwargs,
     ):
@@ -184,7 +184,7 @@ class DodonaCommand(ABC):
 
     def __exit__(
         self,
-        exc_type: type[BaseException],
+        exc_type: Type[BaseException],
         exc_val: BaseException,
         exc_tb: TracebackType,
     ) -> bool:


### PR DESCRIPTION
While looking at this code to re-use some of it in the HTML judge I got some syntax errors and warnings. These two type annotations should use the `typing` package instead (note the first letters being uppercased).

Types with extra specifying parameters between [brackets] can't actually be used as type annotations, which is what the `typing` package solves. `dict` is valid, but `dict[str, str]` is not and should be `Dict[str, str]`.