### PR TITLE
Point config.json at the image the judge actually runs in

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
     "judge": "sql",
-    "image": "dodona-sql"
+    "image": "dodona-sqlite"
 }


### PR DESCRIPTION
This PR fixes a small inconsistency in the example `config.json` where it mentions "dodona-sql" as `judge` instead of `dodona-sqlite`.

<details>
`config.json` claims the judge runs in `dodona-sql`. There's no such image: `ghcr.io/dodona-edu/dodona-sql` returns 403, and `docker-images` builds `dodona-sqlite`.

Nothing is actually broken by this, which is presumably why it survived. Dodona doesn't read this field to pick the image:

```ruby
# app/runners/submission_runner.rb
image_name = @exercise.merged_config['evaluation']&.fetch('image', nil) || @judge.image
```

so it comes from the exercise's evaluation config or the `judges.image` column, and the seeds have `Judge.create! name: 'sql', image: 'dodona-sqlite'`. The field in this repo is documentation, and it's wrong.

Noticed while working on #204, which runs CI inside `ghcr.io/dodona-edu/dodona-sqlite:latest`, so the repo now names two different images for the same judge. Kept it out of that PR to keep it to one thing.

Independent of #204 and of the ruff follow-up, branched straight off `main`, so it can go in whenever.

</details>

## Testing

Nothing to run really, it's a one-line documentation fix that no code path reads. `python3 -c "import json; json.load(open('config.json'))"` still parses.
