### PR TITLE
Replace black, isort and pylama with ruff

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,13 +16,8 @@ updates:
           - "pytest*"
       linters:
         patterns:
-          - "pylama*"
-          - "black"
-          - "isort"
+          - "ruff"
           - "mypy"
-          - "pylint"
-          - "pydocstyle"
-          - "pycodestyle"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,5 +22,5 @@ jobs:
         run: ./devel/install_deps.sh
       - name: Install dev dependencies
         run: ./devel/install_dev_deps.sh
-      - name: Running pylama
+      - name: Run the linters
         run: ./devel/check.sh

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,10 @@
 {
     "editor.formatOnSave": true,
     "python.analysis.typeCheckingMode": "basic",
-    "python.formatting.provider": "black",
-    "python.formatting.blackArgs": [
-        "--line-length=120"
-    ]
+    "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff",
+        "editor.codeActionsOnSave": {
+            "source.organizeImports.ruff": true
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -264,10 +264,10 @@ import pandas as pd
 
 
 def execute_sql_from_file(filename: str):
-    with open(filename, 'r') as file:
+    with open(filename, "r") as file:
         sql_file = file.read()
 
-    sql_commands = sql_file.split(';')
+    sql_commands = sql_file.split(";")
 
     for command in sql_commands:
         try:
@@ -314,10 +314,10 @@ import pandas as pd
 
 
 def execute_sql_from_file(filename: str):
-    with open(filename, 'r') as file:
+    with open(filename, "r") as file:
         sql_file = file.read()
 
-    sql_commands = sql_file.split(';')
+    sql_commands = sql_file.split(";")
 
     for command in sql_commands:
         try:

--- a/devel/check.sh
+++ b/devel/check.sh
@@ -5,7 +5,6 @@ ROOT="$(dirname "$(dirname "$0")")"
 
 cd "$ROOT"
 
-# pylama's pytest plugin registers pytest_collect_file(path, parent), an arg pytest 8 removed, so
-# `pytest --pylama` dies at startup with PluginValidationError. Run pylama directly instead: it
-# decouples linting from the test runner and stops the lint job from collecting/running the suite.
-pylama "$@"
+ruff check .
+ruff format --check .
+mypy sql_judge.py judge/

--- a/devel/format.sh
+++ b/devel/format.sh
@@ -5,5 +5,5 @@ ROOT="$(dirname "$(dirname "$0")")"
 
 cd "$ROOT"
 
-isort .
-black . --line-length=120
+ruff check --fix .
+ruff format .

--- a/judge/dodona_command.py
+++ b/judge/dodona_command.py
@@ -22,7 +22,7 @@ class ErrorType(str, Enum):
     CORRECT = "correct"
     CORRECT_ANSWER = "correct answer"
 
-    def __str__(self) -> str:  # noqa: E0307
+    def __str__(self) -> str:
         """Convert enum to string.
 
         Returns:
@@ -38,7 +38,7 @@ class MessagePermission(str, Enum):
     STAFF = "staff"
     ZEUS = "zeus"
 
-    def __str__(self) -> str:  # noqa: E0307
+    def __str__(self) -> str:
         """Convert enum to string.
 
         Returns:
@@ -61,7 +61,7 @@ class MessageFormat(str, Enum):
     CODE = "code"
     SQL = "sql"
 
-    def __str__(self) -> str:  # noqa: E0307
+    def __str__(self) -> str:
         """Convert enum to string.
 
         Returns:
@@ -77,7 +77,7 @@ class AnnotationSeverity(str, Enum):
     WARNING = "warning"
     INFO = "info"
 
-    def __str__(self) -> str:  # noqa: E0307
+    def __str__(self) -> str:
         """Convert enum to string.
 
         Returns:

--- a/judge/dodona_config.py
+++ b/judge/dodona_config.py
@@ -6,7 +6,8 @@ from types import SimpleNamespace
 from typing import Any, Union
 
 
-class DodonaConfig(SimpleNamespace):  # noqa: R0902
+# Deliberately unhashable: this object is mutable, so it shouldn't define __hash__ alongside __eq__.
+class DodonaConfig(SimpleNamespace):  # noqa: PLW1641
     """a class for containing all Dodona Judge configuration.
 
     Attributes:

--- a/judge/sql_judge_non_select_feedback.py
+++ b/judge/sql_judge_non_select_feedback.py
@@ -15,7 +15,7 @@ from .sql_query import SQLQuery
 from .translator import Translator
 
 
-def non_select_feedback(  # noqa: C901
+def non_select_feedback(
     config: DodonaConfig, testcase: SimpleNamespace, db_name: str, db_file: str, solution_query: SQLQuery
 ) -> None:
     """Run tests based on execution results of a select query.

--- a/judge/sql_judge_select_feedback.py
+++ b/judge/sql_judge_select_feedback.py
@@ -19,7 +19,7 @@ from .sql_query_result import SQLQueryResult
 from .translator import Translator
 
 
-def select_feedback(  # noqa: R0913
+def select_feedback(  # noqa: PLR0913, PLR0917
     config: DodonaConfig,
     testcase: SimpleNamespace,
     expected_output: SQLQueryResult,
@@ -45,7 +45,7 @@ def select_feedback(  # noqa: R0913
 
     # if SELECT is not ordered -> fix ordering by sorting all rows
     if config.order_unordered_rows and not solution_query.is_ordered:
-        sort_on = np.intersect1d(expected_output.columns, generated_output.columns)
+        sort_on = np.intersect1d(expected_output.columns, generated_output.columns).tolist()
         expected_output.sort_rows(sort_on)
         generated_output.sort_rows(sort_on)
 
@@ -86,7 +86,7 @@ def select_feedback(  # noqa: R0913
 
             # if SELECT is ordered -> check if rows are correct but order is wrong
             if solution_query.is_ordered:
-                sort_on = np.intersect1d(expected_output.columns, generated_output.columns)
+                sort_on = np.intersect1d(expected_output.columns, generated_output.columns).tolist()
                 expected_output.sort_rows(sort_on)
                 generated_output.sort_rows(sort_on)
 

--- a/pylama.ini
+++ b/pylama.ini
@@ -1,8 +1,0 @@
-[pylama]
-format = pylint
-linters = eradicate,mccabe,mypy,pycodestyle,pydocstyle,pyflakes,pylint,isort
-skip = tests/*
-max_line_length = 120
-
-[pylama:pydocstyle]
-convention = google

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,3 @@
-[tool.isort]
-profile = "black"
-skip = ["tests/e2e_repos"]
-
-[tool.black]
-line-length = 120
-extend-exclude = "tests/e2e_repos"
-
-# pylama ships a pytest11 entry point that auto-loads whenever installed.
-# Its pytest_collect_file(path, parent) hook uses the path argument removed in pytest 8, causing PluginValidationError.
-[tool.pytest.ini_options]
-addopts = "-p no:pylama"
-
 [tool.coverage.run]
 omit = [
     ".github/*",
@@ -20,3 +7,19 @@ omit = [
     "venv/*",
 ]
 source = ["."]
+
+[tool.ruff]
+line-length = 120
+extend-exclude = ["tests/e2e_repos"]
+# Keep in step with .tool-versions; ruff defaults to py310 and can't infer it without a [project] table.
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "D", "C90", "I", "ERA", "PL", "RUF100"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.per-file-ignores]
+# Ignores rather than an exclude, so `ruff format` still applies to the tests.
+"tests/*" = ["ALL"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,19 +1,4 @@
 -r requirements-test.txt
 
-black==24.3.0
-isort==5.10.1
-
-# pylama 8.4.1 (the final, unmaintained release) leaves its bundled linters unpinned; four years of
-# drift in those linters has now broken the lint job. Pin what it drags in unpinned:
-pylama[all]==8.4.1
-# pylama 8.4.1 does `from pkg_resources import iter_entry_points`, removed in setuptools 82; 80.9.0
-# already emits that as a loud UserWarning. Range cap (already satisfied) so Dependabot leaves it alone.
-setuptools<80.9.0
-# pydocstyle 6.2 inserted a `property_decorators` param that shifts pylama's positional call,
-# raising `TypeError` in `is_property()`. Range cap (already satisfied) so Dependabot leaves it alone.
-pydocstyle<6.2
-# pylama[all] also leaves mypy and pylint floating, so what CI enforces changes silently under us.
-# Pin them (exact, unlike the caps above) so the rule set is reproducible and the grouped Dependabot
-# PR surfaces each bump for review.
+ruff==0.16.3
 mypy==2.3.1
-pylint==4.0.7

--- a/sql_judge.py
+++ b/sql_judge.py
@@ -163,7 +163,7 @@ with Judgement():
         ):
             pass
 
-    for query_nr, solution_query in enumerate(config.solution_queries):  # noqa: C901
+    for query_nr, solution_query in enumerate(config.solution_queries):
         with Tab(f"Query {1 + query_nr}"):
             if query_nr >= len(config.submission_queries):
                 raise DodonaException(
@@ -208,10 +208,13 @@ with Judgement():
                 )
 
             for db_name, db_file in config.database_files:
-                with Context(), TestCase(
-                    format=MessageFormat.SQL,
-                    description=f"-- sqlite3 {db_name}\n{submission_query.without_comments}",
-                ) as testcase:
+                with (
+                    Context(),
+                    TestCase(
+                        format=MessageFormat.SQL,
+                        description=f"-- sqlite3 {db_name}\n{submission_query.without_comments}",
+                    ) as testcase,
+                ):
                     expected_output: SQLQueryResult
                     generated_output: SQLQueryResult
 

--- a/tests/test_sql_query_result.py
+++ b/tests/test_sql_query_result.py
@@ -25,11 +25,25 @@ class TestSQLQueryResult(unittest.TestCase):
 
         self.assertMultiLineEqual(
             query_result.csv_out,
-            "col1,col3,col2\n" "19,Tom,20\n" "11,nick,21\n" "17,krish,19\n" "18,jack,18",
+            "\n".join(
+                [
+                    "col1,col3,col2",
+                    "19,Tom,20",
+                    "11,nick,21",
+                    "17,krish,19",
+                    "18,jack,18",
+                ]
+            ),
         )
         self.assertMultiLineEqual(
             query_result.types_out,
-            "col1 [INTEGER]\n" "col3 [TEXT]\n" "col2 [INTEGER]",
+            "\n".join(
+                [
+                    "col1 [INTEGER]",
+                    "col3 [TEXT]",
+                    "col2 [INTEGER]",
+                ]
+            ),
         )
 
         self.assertSequenceEqual(query_result.columns, ["col1", "col3", "col2"])
@@ -38,11 +52,25 @@ class TestSQLQueryResult(unittest.TestCase):
 
         self.assertMultiLineEqual(
             query_result.csv_out,
-            "col3,col1,col2\n" "Tom,19,20\n" "jack,18,18\n" "krish,17,19\n" "nick,11,21",
+            "\n".join(
+                [
+                    "col3,col1,col2",
+                    "Tom,19,20",
+                    "jack,18,18",
+                    "krish,17,19",
+                    "nick,11,21",
+                ]
+            ),
         )
         self.assertMultiLineEqual(
             query_result.types_out,
-            "col3 [TEXT]\n" "col1 [INTEGER]\n" "col2 [INTEGER]",
+            "\n".join(
+                [
+                    "col3 [TEXT]",
+                    "col1 [INTEGER]",
+                    "col2 [INTEGER]",
+                ]
+            ),
         )
 
     def test_init2(self):
@@ -54,16 +82,73 @@ class TestSQLQueryResult(unittest.TestCase):
             [str, int, int],
         )
 
-        self.assertMultiLineEqual(query_result.csv_out, "Name,Test,Name\n" "tom,2,10\n" "nick,2,15\n" "juli,2,14")
-        self.assertMultiLineEqual(query_result.types_out, "Name [TEXT]\n" "Test [INTEGER]\n" "Name [INTEGER]")
+        self.assertMultiLineEqual(
+            query_result.csv_out,
+            "\n".join(
+                [
+                    "Name,Test,Name",
+                    "tom,2,10",
+                    "nick,2,15",
+                    "juli,2,14",
+                ]
+            ),
+        )
+        self.assertMultiLineEqual(
+            query_result.types_out,
+            "\n".join(
+                [
+                    "Name [TEXT]",
+                    "Test [INTEGER]",
+                    "Name [INTEGER]",
+                ]
+            ),
+        )
 
         query_result.index_columns(["Name", "Test"])  # should keep both columns & keep ordering (stable)
         query_result.sort_rows(["Name"])
 
-        self.assertMultiLineEqual(query_result.csv_out, "Name,Test,Name\n" "juli,2,14\n" "nick,2,15\n" "tom,2,10")
-        self.assertMultiLineEqual(query_result.types_out, "Name [TEXT]\n" "Test [INTEGER]\n" "Name [INTEGER]")
+        self.assertMultiLineEqual(
+            query_result.csv_out,
+            "\n".join(
+                [
+                    "Name,Test,Name",
+                    "juli,2,14",
+                    "nick,2,15",
+                    "tom,2,10",
+                ]
+            ),
+        )
+        self.assertMultiLineEqual(
+            query_result.types_out,
+            "\n".join(
+                [
+                    "Name [TEXT]",
+                    "Test [INTEGER]",
+                    "Name [INTEGER]",
+                ]
+            ),
+        )
 
         query_result.sort_rows([])  # noop
 
-        self.assertMultiLineEqual(query_result.csv_out, "Name,Test,Name\n" "juli,2,14\n" "nick,2,15\n" "tom,2,10")
-        self.assertMultiLineEqual(query_result.types_out, "Name [TEXT]\n" "Test [INTEGER]\n" "Name [INTEGER]")
+        self.assertMultiLineEqual(
+            query_result.csv_out,
+            "\n".join(
+                [
+                    "Name,Test,Name",
+                    "juli,2,14",
+                    "nick,2,15",
+                    "tom,2,10",
+                ]
+            ),
+        )
+        self.assertMultiLineEqual(
+            query_result.types_out,
+            "\n".join(
+                [
+                    "Name [TEXT]",
+                    "Test [INTEGER]",
+                    "Name [INTEGER]",
+                ]
+            ),
+        )


### PR DESCRIPTION
This PR replaces black, isort and pylama with ruff. 

This just does the basic 1-on-1 replacement (with some changes where needed), for follow up PRs:
- Lint test code too
- See if we can expand the ruleset to not have too many custom exclusions
- Replace `mypy` with `ty`

<details>
Follow-up to #204, where keeping pylama alive on Python 3.12 turned out to cost more than it was worth. pylama 8.4.1 is the final release (August 2022) and the project is unmaintained, so #204 had to pin around it in four separate places. All four go away here:

- `setuptools<80.9.0`, because pylama imports `pkg_resources`
- `pydocstyle<6.2`, because 6.2 reordered a positional parameter pylama passes
- exact `mypy` and `pylint` pins, because `pylama[all]` leaves its linters floating
- `addopts = "-p no:pylama"`, because pylama's pytest plugin crashes any pytest 8+ run

`requirements-dev.txt` is now `ruff` + `mypy`, and `pylama.ini` is gone.

## Rule selection

A direct translation of what `pylama.ini` enforced (`eradicate,mccabe,pycodestyle,pydocstyle,pyflakes,pylint,isort`) into `E, W, F, D, C90, I, ERA, PL`, keeping the google docstring convention and line length 120.

**`UP` (pyupgrade) and `B` (bugbear) are deliberately left out.** Both come out with real findings, 12 and 2 respectively: `Optional[X]` to `X | None`, dropping the redundant `"r"` from `open()`, `zip()` without `strict=`, an ABC with no abstract methods. All arguably worth doing, none of them lint-toolchain-swap work, and I'd rather not either fix a dozen unrelated things here or blanket-ignore the codes. Easy follow-up if you want them.

Tests stay out of linting via `per-file-ignores` rather than a top-level exclude, because black and isort *did* format `tests/` and only pylama's linting skipped it. An exclude would have quietly changed that.

## Two things that came out of it

**mypy found a real type bug.** pylama ran mypy with `--follow-imports=skip` on a per-file basis, so it never actually looked across modules. Run properly, it flags that `np.intersect1d(...)` returns an `ndarray` while `sort_rows` is annotated `list[str]`. Fixed with `.tolist()` at both call sites in `sql_judge_select_feedback.py`. No runtime change, the downstream `in` and iteration work either way.

**ruff format does two things black didn't**, which between them account for the `README.md` and `tests/test_sql_query_result.py` diffs. Flagging both rather than letting you find them in review:

- It formats Python code blocks inside Markdown, so two generator-script examples in the README pick up double quotes.
- It joins implicitly-concatenated string literals that fit on one line, which collapsed the expected CSV data in `test_sql_query_result.py` from one literal per row onto single lines. There's no setting to turn that off in 0.16.3 and `# fmt: skip` doesn't stop it (both checked), so those assertions are now written as `"\n".join([...])` with a magic trailing comma, which ruff leaves alone. That's the bulk of this PR's test diff, and it reads better than either previous form: one CSV row per line, without the `\n` noise repeated inside every literal.

<details>
<summary>The noqa comments needed translating too</summary>

The existing suppressions used pylint's numeric codes, which ruff doesn't understand:

- `E0307` on the four `__str__` methods: removed. Ruff's `PLE0307` doesn't fire on `str, Enum` subclasses returning a `str` field, confirmed by an empty diff after removing them.
- `R0902` (too many instance attributes) on `DodonaConfig`: removed, ruff has no equivalent (`PLR0902` doesn't exist).
- `R0913` on `select_feedback`: becomes `PLR0913, PLR0917`, since ruff splits "too many arguments" into two rules.
- One new suppression, `PLW1641` on `DodonaConfig`: it defines `__eq__` on a mutable `SimpleNamespace` and deliberately has no `__hash__`. Adding one would be unsound for a mutable object, so this is a rule that doesn't suit the design rather than a bug. Commented in place.

Also added `target-version = "py312"`. Without a `[project] requires-python`, ruff defaults to py310, which is stale now the toolchain targets 3.12.

</details>
</details>

## Testing

`devel/check.sh` now runs `ruff check` then `ruff format --check` then `mypy sql_judge.py judge/`, relying on the `set -euo pipefail` that's already there. It no longer forwards `"$@"`: nothing in the repo, CI or the README ever passed it an argument, and only one of the three commands could have honoured it, so `devel/check.sh --fix` would have silently half-worked.

```
$ devel/check.sh
All checks passed!
19 files already formatted
Success: no issues found in 10 source files
```

- `pytest tests/ -q` and `-n auto`: **76 passed** both ways. This also confirms dropping `-p no:pylama` is safe, which was the whole reason that workaround existed.
- In the production image (`ghcr.io/dodona-edu/dodona-sqlite:latest`, the thing #204 set up): **76 passed**, Python 3.12.9.
- Gate still bites: a 136-char line in `judge/translator.py` makes `check.sh` exit 1 with `E501 Line too long (136 > 120)`.
- `devel/format.sh` (now `ruff check --fix .` then `ruff format .`) is a no-op on the formatted tree.

`lint.yml` only changes in that its step was still called "Running pylama"; it calls `devel/check.sh` and `devel/install_dev_deps.sh`, both of which keep working as-is.

<details>

## Follow-ups

Deliberately not in here, roughly in the order I'd do them:

1. **Lint the tests.** They're first-class code, but `pyproject.toml` ignores every rule for `tests/*`, purely inherited from pylama's `skip = tests/*`. Lifting it gives **24 findings**, 22 of which are docstring rules on unittest methods (`D102` ×21, `D103` ×1). The entire rest is one auto-fixable `I001` in `test_dodona_command.py` and one `PLR0915` (55 statements > 50) in `test_sql_query.py:254`. So "ignore `D` for tests, enforce the rest" is about a two-line change. Worth doing: mypy already skips `tests/` entirely, so ruff's `F` rules are the only static checking the suite would get, and today it gets none.
2. **Turn on `UP` (pyupgrade) and `B` (bugbear).** 12 and 2 findings respectively: `Optional[X]` to `X | None`, redundant `"r"` in `open()`, `zip()` without `strict=`, an ABC with no abstract methods. All real, none urgent.
3. **Drop the pandas and sqlparse install from the lint job.** Measured: mypy needs only `numpy`, because the pandas and sqlparse imports already carry `# type: ignore`, and ruff needs none of the three. `lint.yml` installs all of `requirements.txt` on every run.
4. **Drop numpy from the judge.** Its only use is `np.intersect1d(a, b)` at two call sites, which is `sorted(set(a) & set(b))` in the stdlib. That also removes the `.tolist()` added here. Left alone on purpose for now.
5. **`RUF012`.** The wider `RUF` group isn't clean: two mutable class-attribute defaults in `judge/translator.py`. Only `RUF100` is enabled here.
6. **Swap `mypy` for `ty`.** Astral's type checker, so the same people as ruff, and it would finish the job of getting this repo onto one fast toolchain instead of two. Not yet: it's on 0.0.72 and still classified beta, so it wants to settle first. mypy is the only reason a Python dependency is needed for the lint job at all, so this also feeds into follow-up 3.

</details>

