### PR TITLE
Enable ruff's RUF rule group

### DIFF
--- a/judge/translator.py
+++ b/judge/translator.py
@@ -1,7 +1,7 @@
 """translate judge output towards Dodona."""
 
 from enum import Enum, auto
-from typing import Any
+from typing import Any, ClassVar
 
 from .dodona_command import ErrorType
 
@@ -107,7 +107,7 @@ class Translator:
         """
         return self.text_translations[self.language][message].format(**kwargs)
 
-    error_translations = {
+    error_translations: ClassVar[dict[Language, dict[ErrorType, str]]] = {
         Language.EN: {
             ErrorType.INTERNAL_ERROR: "Internal error",
             ErrorType.COMPILATION_ERROR: "The query is not valid",
@@ -134,7 +134,7 @@ class Translator:
         },
     }
 
-    text_translations = {
+    text_translations: ClassVar[dict[Language, dict[Text, str]]] = {
         Language.EN: {
             Text.ADD_A_SEMICOLON: "Add a semicolon ';' at the end of each SQL query.",
             Text.INVALID_SINGLE_QUOTE_TABLE_NAME: "Error: "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ extend-exclude = ["tests/e2e_repos"]
 target-version = "py312"
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "D", "C90", "I", "ERA", "PL", "RUF012", "RUF100"]
+select = ["E", "W", "F", "D", "C90", "I", "ERA", "PL", "RUF"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ extend-exclude = ["tests/e2e_repos"]
 target-version = "py312"
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "D", "C90", "I", "ERA", "PL", "RUF100"]
+select = ["E", "W", "F", "D", "C90", "I", "ERA", "PL", "RUF012", "RUF100"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
This PR annotates 2 mutable class attribute defaults with `typing.ClassVar` so the whole `RUF` group can be enabled.

<details>
#206 enabled only `RUF100` from the `RUF` group, since the wider group flagged two spots in `judge/translator.py`. This fixes those and enables `RUF012`.

## Findings

`RUF012` (mutable class attribute defaults should be annotated `typing.ClassVar`) flagged:

- `Translator.error_translations` (`judge/translator.py:110`)
- `Translator.text_translations` (`judge/translator.py:137`)

Both are read-only lookup tables: never assigned in `__init__`, never mutated or reassigned anywhere in the class, only read via `self.error_translations[...]` / `self.text_translations[...]`. Annotated both as `typing.ClassVar[dict[Language, dict[ErrorType, str]]]` and `typing.ClassVar[dict[Language, dict[Text, str]]]` respectively.

`select` in `[tool.ruff.lint]` now carries `"RUF"`, which subsumes both `RUF012` and the `RUF100` that #206 enabled.


## Wider `RUF` group

With those two annotated, the whole group is clean, so `select` takes `"RUF"` rather than listing individual codes. Nothing beyond `RUF012` fires, and `RUF100` is subsumed rather than dropped: verified by planting a bogus `# noqa: E501` on a line with no violation and confirming ruff still reports it as an unused directive.

</details>


## Verification

- `ruff check --extend-select RUF012 .` and `ruff check --extend-select RUF .`: both clean
- `./devel/check.sh`: passes (ruff + mypy)
- `pytest tests/ -q` and `-n auto`: 76 passed
- `ruff format .`: no-op
- `tests/e2e_stdout` goldens: unchanged

