### PR TITLE
Lint the tests instead of blanket-ignoring them

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,5 +21,6 @@ select = ["E", "W", "F", "D", "C90", "I", "ERA", "PL", "RUF100"]
 convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
-# Ignores rather than an exclude, so `ruff format` still applies to the tests.
-"tests/*" = ["ALL"]
+# Tests are linted like any other code; only docstrings are exempted, since nobody
+# writes docstrings on individual unittest methods.
+"tests/*" = ["D"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,5 @@ select = ["E", "W", "F", "D", "C90", "I", "ERA", "PL", "RUF100"]
 convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
-# Tests are linted like any other code; only docstrings are exempted, since nobody
-# writes docstrings on individual unittest methods.
-"tests/*" = ["D"]
+# Tests don't require docstrings on methods and functions (D102, D103), but docstring formatting rules still apply.
+"tests/*" = ["D102", "D103"]

--- a/tests/test_dodona_command.py
+++ b/tests/test_dodona_command.py
@@ -2,9 +2,8 @@
 
 import unittest
 
-from judge.dodona_command import AnnotationSeverity, ErrorType
+from judge.dodona_command import AnnotationSeverity, ErrorType, MessageFormat, MessagePermission
 from judge.dodona_command import Message as CommandMessage
-from judge.dodona_command import MessageFormat, MessagePermission
 from judge.dodona_command import TestCase as CommandTestCase
 
 

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -251,7 +251,7 @@ class TestSQLQuery(unittest.TestCase):
         query = self.single_query("INSERT INTO table2 SELECT * FROM table1 WHERE condition;")
         self.assertEqual(query.query_type, "INSERT")
 
-    def test_match_keywords(self):
+    def test_match_keywords(self):  # noqa: PLR0915 -- one-off, splitting the assertions up would be artificial
         query = self.single_query('select * from users WHERE zip LIKE "test"')
         self.assertEqual(query.symbols, ["select", "*", "from", "users", "WHERE", "zip", "LIKE", '"test"'])
         self.assertEqual(query.first_match_regex("LIKE"), "LIKE")


### PR DESCRIPTION
This PR lints the tests too, since that's first-class code anyway. Not many changes were required. I ignored D102 and D103 since those are docstring requirements (docstring formatting rules still apply if we would have those).

<details>

## Why

#206 carried pylama's `skip = tests/*` over into ruff as a blanket per-file-ignore (`"tests/*" = ["ALL"]`). That was inherited habit, not a decision: tests are first-class code and mypy already skips `tests/` (`devel/check.sh` only runs it on `sql_judge.py` and `judge/`), so ruff was the only static check the suite could get, and it got none.

## What changed

Narrowed the ignore to the two missing-docstring rules:

```toml
[tool.ruff.lint.per-file-ignores]
# Tests don't require docstrings on methods and functions (D102, D103), but docstring formatting rules still apply.
"tests/*" = ["D102", "D103"]
```

Ignoring all of `D` would also have switched off docstring *formatting* for the docstrings the tests already have, and `tests/test_e2e.py` has proper Google-style ones with `Args:` sections. Verified both directions: breaking a summary line in `tests/test_e2e.py` now gets flagged `D415`, where under `["D"]` it was invisible, and a test method with no docstring at all is still silent.

With the blanket ignore lifted, the current tree has 24 findings across 6 files:
- `D102` undocumented-public-method: 21
- `D103` undocumented-public-function: 1
- `I001` unsorted-imports: 1 (auto-fixable)
- `PLR0915` too-many-statements: 1

22 of the 24 are missing-docstring findings, hence keeping `D102`/`D103` off for tests. The other two:

- `I001` in `tests/test_dodona_command.py`: fixed with `ruff check --fix`.
- `PLR0915` on `test_match_keywords` in `tests/test_sql_query.py` (55 > 50 statements): silenced with a targeted `# noqa: PLR0915` and a reason, rather than raising `max-statements` in config. It's a one-off linear sequence of assertions over several queries, splitting it up would be artificial, and a config bump would relax the limit for all future code too.

No new rule categories enabled, only what `tests/*` ignores changed. `tests/e2e_repos` (the third-party submodule) stays excluded via the existing `extend-exclude`; `ruff check .` doesn't descend into it.

## Verification

<details>
<summary>devel/check.sh</summary>

```
$ PATH=<venv>/bin:$PATH ./devel/check.sh
All checks passed!
19 files already formatted
Success: no issues found in 10 source files
```
</details>

<details>
<summary>pytest, single-process and -n auto</summary>

```
$ python -m pytest tests/ -q
76 passed in 0.49s

$ python -m pytest tests/ -n auto -q
76 passed in 1.93s
```
</details>

`ruff format .` is a no-op on the branch (`19 files already formatted`).

Proof the tests are actually linted now: added `import sys` (unused) to `tests/test_translator.py`, ran `ruff check .`:

```
F401 [*] `sys` imported but unused
 --> tests/test_translator.py:5:8
  |
3 | import unittest
4 |
5 | import sys
  |        ^^^
6 |
7 | from judge.dodona_command import ErrorType
  |
help: Remove unused import: `sys`
```

Reverted exactly afterwards; `git status --short` clean.


</details>