### PR TITLE
Drop the direct numpy dependency in the SQL judge

### DIFF
--- a/judge/sql_judge_select_feedback.py
+++ b/judge/sql_judge_select_feedback.py
@@ -2,8 +2,6 @@
 
 from types import SimpleNamespace
 
-import numpy as np
-
 from .dodona_command import (
     Context,
     DodonaException,
@@ -45,7 +43,7 @@ def select_feedback(  # noqa: PLR0913, PLR0917
 
     # if SELECT is not ordered -> fix ordering by sorting all rows
     if config.order_unordered_rows and not solution_query.is_ordered:
-        sort_on = np.intersect1d(expected_output.columns, generated_output.columns).tolist()
+        sort_on = sorted(set(expected_output.columns) & set(generated_output.columns))
         expected_output.sort_rows(sort_on)
         generated_output.sort_rows(sort_on)
 
@@ -86,7 +84,7 @@ def select_feedback(  # noqa: PLR0913, PLR0917
 
             # if SELECT is ordered -> check if rows are correct but order is wrong
             if solution_query.is_ordered:
-                sort_on = np.intersect1d(expected_output.columns, generated_output.columns).tolist()
+                sort_on = sorted(set(expected_output.columns) & set(generated_output.columns))
                 expected_output.sort_rows(sort_on)
                 generated_output.sort_rows(sort_on)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-# pandas 2.1.1 is built against numpy 1.x; a plain `pip install` today pulls numpy 2.x, which fails at
-# import with "ValueError: numpy.dtype size changed". 1.26.4 is what the production dodona-sqlite image
-# ships, so pin it here to keep this file in step with the image.
+# Transitive pin, not a direct dependency: pandas 2.1.1 is built against numpy 1.x, so an unpinned install pulls numpy 2.x and fails at import with "ValueError: numpy.dtype size changed".
 numpy==1.26.4
 pandas==2.1.1
 sqlparse==0.4.4


### PR DESCRIPTION
This PR drops the direct numpy dependency in the SQL judge. It's still there as a transitive dependency of pandas, which we might want to remove in the future in https://github.com/dodona-edu/judge-sql/issues/218.

<details>

## What

`judge/sql_judge_select_feedback.py` was the only file in the judge importing numpy, and it used exactly one function, at two call sites:

```python
sort_on = np.intersect1d(expected_output.columns, generated_output.columns).tolist()
```

Replaced with the stdlib equivalent:

```python
sort_on = sorted(set(expected_output.columns) & set(generated_output.columns))
```

which already returns a `list[str]`, so the `.tolist()` workaround goes with it. Removed the now-unused `import numpy as np`.

## Equivalence

`np.intersect1d` returns the sorted, deduplicated intersection. Columns can genuinely contain duplicates (the judge deliberately supports queries that return several columns with the same name, see `SQLQueryResult.from_cursor`), so I compared both expressions across duplicate, empty and no-overlap cases before relying on this:

```
'no overlap'                            expected=['A', 'B']           generated=['C', 'D']           np=[]                stdlib=[]                match=True
'full overlap'                          expected=['A', 'B', 'C']      generated=['A', 'B', 'C']      np=['A', 'B', 'C']   stdlib=['A', 'B', 'C']   match=True
'partial overlap'                       expected=['A', 'B', 'C']      generated=['B', 'C', 'D']      np=['B', 'C']        stdlib=['B', 'C']        match=True
'empty expected'                        expected=[]                   generated=['A', 'B']           np=[]                stdlib=[]                match=True
'empty generated'                       expected=['A', 'B']           generated=[]                   np=[]                stdlib=[]                match=True
'both empty'                            expected=[]                   generated=[]                   np=[]                stdlib=[]                match=True
'duplicates in expected'                expected=['A', 'A', 'B']      generated=['A', 'B']           np=['A', 'B']        stdlib=['A', 'B']        match=True
'duplicates in generated'               expected=['A', 'B']           generated=['B', 'B', 'C']      np=['B']             stdlib=['B']             match=True
'duplicates in both, same cols'         expected=['A', 'A', 'B', 'B'] generated=['A', 'B', 'B']      np=['A', 'B']        stdlib=['A', 'B']        match=True
'duplicates, no overlap'                expected=['A', 'A']           generated=['B', 'B']           np=[]                stdlib=[]                match=True
'unsorted input'                        expected=['C', 'A', 'B']      generated=['B', 'A', 'C']      np=['A', 'B', 'C']   stdlib=['A', 'B', 'C']   match=True
'single column each, equal'             expected=['ID']               generated=['ID']               np=['ID']            stdlib=['ID']            match=True
'single column each, different'         expected=['ID']               generated=['NAME']             np=[]                stdlib=[]                match=True

ALL MATCH
```

`sort_on` is only ever used as a membership filter in `SQLQueryResult.sort_rows` (`x in sort_on`), so neither the sort order nor the dedup of the list itself changes any behaviour beyond producing the same set of column names.

`tests/e2e_stdout` (the exact judge output goldens) are unchanged by this, verified with `git status --short tests/e2e_stdout` before and after the full test run.

## The numpy pin stays

`requirements.txt` still pins `numpy==1.26.4`. This is **not** removed, on purpose. pandas 2.1.1 declares `numpy>=1.26.0`, which on Python 3.12 permits numpy 2.x, but pandas 2.1.1 is built against numpy 1.x. In a scratch venv, `pip install pandas==2.1.1 sqlparse==0.4.4` without the pin resolves `numpy-2.5.2`, and `import pandas` then fails with:

```
ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```

So the pin is still load-bearing, it's just no longer justified by a direct import from the judge. Reworded the comment above it to say that in one line, instead of removing it.

## This does not shrink the Docker image

pandas 2.1.1 declares numpy as a hard runtime dependency, so numpy stays installed in `ghcr.io/dodona-edu/dodona-sqlite:latest` regardless of this change (numpy is 39M, pandas 72M, of a 165M site-packages there). Dropping numpy from the image would mean dropping pandas from the judge, which is a separate, much bigger refactor and out of scope here. This PR is just dropping a direct dependency the judge barely used, in favour of one line of stdlib.

That refactor is filed as #218, with dodona-edu/docker-images#433 tracking the image side once it lands. After this PR, pandas is the only remaining reason either package is installed.

</details>

## Verification

- `ruff check .`, `ruff format --check .`, `mypy sql_judge.py judge/` (ruff 0.16.3) all pass.
- `pytest tests/ -q` → 76 passed, `-n auto` → 76 passed.
- `git status --short tests/e2e_stdout` clean before and after.
- Full suite inside `ghcr.io/dodona-edu/dodona-sqlite:latest` via `devel/install_test_deps.sh` + `devel/run-tests.sh` → 76 passed.

