### PR TITLE
Swap transposed docstring summaries for select/non-select feedback

### DIFF
--- a/judge/sql_judge_non_select_feedback.py
+++ b/judge/sql_judge_non_select_feedback.py
@@ -18,7 +18,7 @@ from .translator import Translator
 def non_select_feedback(  # noqa: C901
     config: DodonaConfig, testcase: SimpleNamespace, db_name: str, db_file: str, solution_query: SQLQuery
 ) -> None:
-    """Run tests based on execution results of a select query.
+    """Run tests based on database status after running a non-select query.
 
     Args:
         config: parsed config received from Dodona

--- a/judge/sql_judge_select_feedback.py
+++ b/judge/sql_judge_select_feedback.py
@@ -27,7 +27,7 @@ def select_feedback(  # noqa: R0913
     solution_query: SQLQuery,
     submission_query: SQLQuery,
 ) -> None:
-    """Run tests based on database status after running a non-select query.
+    """Run tests based on execution results of a select query.
 
     Args:
         config: parsed config received from Dodona


### PR DESCRIPTION
The summary lines of two sibling functions are transposed. `non_select_feedback` inspects database state after a write query, but its docstring claims it tests select query results. Meanwhile, `select_feedback` compares query result sets, but its docstring claims it tests database state.

Before:
- `non_select_feedback`: "Run tests based on execution results of a select query."
- `select_feedback`: "Run tests based on database status after running a non-select query."

After:
- `non_select_feedback`: "Run tests based on database status after running a non-select query."
- `select_feedback`: "Run tests based on execution results of a select query."

Copilot spotted one half of this while reviewing #206.
