### PR TITLE
Enable pyupgrade and flake8-bugbear ruff rules

### DIFF
--- a/judge/dodona_command.py
+++ b/judge/dodona_command.py
@@ -2,13 +2,12 @@
 
 import json
 import sys
-from abc import ABC
-from enum import Enum
+from enum import StrEnum
 from types import SimpleNamespace, TracebackType
-from typing import Any, Optional, Union
+from typing import Any
 
 
-class ErrorType(str, Enum):
+class ErrorType(StrEnum):
     """Dodona error type."""
 
     INTERNAL_ERROR = "internal error"
@@ -31,7 +30,7 @@ class ErrorType(str, Enum):
         return self
 
 
-class MessagePermission(str, Enum):
+class MessagePermission(StrEnum):
     """Dodona permission for a message."""
 
     STUDENT = "student"
@@ -47,7 +46,7 @@ class MessagePermission(str, Enum):
         return self
 
 
-class MessageFormat(str, Enum):
+class MessageFormat(StrEnum):
     """Dodona format for a message."""
 
     PLAIN = "plain"
@@ -70,7 +69,7 @@ class MessageFormat(str, Enum):
         return self
 
 
-class AnnotationSeverity(str, Enum):
+class AnnotationSeverity(StrEnum):
     """Dodona severity of an annotation."""
 
     ERROR = "error"
@@ -100,7 +99,7 @@ class DodonaException(Exception):
     def __init__(
         self,
         status: dict[str, str],
-        recover_at: Optional[type] = None,
+        recover_at: type | None = None,
         **kwargs: Any,
     ) -> None:
         """Create DodonaException.
@@ -122,7 +121,7 @@ class DodonaException(Exception):
         self.message = Message(**kwargs) if len(kwargs) > 0 else None
 
 
-class DodonaCommand(ABC):
+class DodonaCommand:
     """Abstract class, parent of all Dodona commands.
 
     This class provides all shared functionality for the Dodona commands. These commands
@@ -182,7 +181,7 @@ class DodonaCommand(ABC):
         """
         return {"command": f"start-{self.name()}", **self.start_args.__dict__}
 
-    def close_msg(self) -> Optional[dict]:
+    def close_msg(self) -> dict | None:
         """Create close message that is printed as JSON to stdout when exiting the 'with' block.
 
         Returns:
@@ -191,7 +190,7 @@ class DodonaCommand(ABC):
         return {"command": f"close-{self.name()}", **self.close_args.__dict__}
 
     @staticmethod
-    def __print_command(result: Optional[dict]) -> None:
+    def __print_command(result: dict | None) -> None:
         """Print the provided to stdout as JSON.
 
         Args:
@@ -378,7 +377,7 @@ class TestCase(DodonaCommandWithAccepted):
 class Test(DodonaCommandWithStatus):
     """Dodona Test."""
 
-    def __init__(self, description: Union[str, dict], expected: str, **kwargs: Any) -> None:
+    def __init__(self, description: str | dict, expected: str, **kwargs: Any) -> None:
         """Create Test.
 
         Args:

--- a/judge/dodona_command.py
+++ b/judge/dodona_command.py
@@ -122,7 +122,7 @@ class DodonaException(Exception):
 
 
 class DodonaCommand:
-    """Abstract class, parent of all Dodona commands.
+    """Base class providing shared behaviour for the Dodona command context managers.
 
     This class provides all shared functionality for the Dodona commands. These commands
     should be used in a Python 'with' block.
@@ -191,7 +191,7 @@ class DodonaCommand:
 
     @staticmethod
     def __print_command(result: dict | None) -> None:
-        """Print the provided to stdout as JSON.
+        """Print the provided result to stdout as JSON.
 
         Args:
             result: dict that will be JSON encoded and printed to stdout

--- a/judge/dodona_config.py
+++ b/judge/dodona_config.py
@@ -3,7 +3,7 @@
 import json
 import os
 from types import SimpleNamespace
-from typing import Any, Union
+from typing import Any
 
 
 # Deliberately unhashable: this object is mutable, so it shouldn't define __hash__ alongside __eq__.
@@ -61,7 +61,7 @@ class DodonaConfig(SimpleNamespace):  # noqa: PLW1641
         return super().__eq__(other)
 
     @classmethod
-    def from_json(cls: type["DodonaConfig"], json_str: Union[str, bytes]) -> "DodonaConfig":
+    def from_json(cls: type["DodonaConfig"], json_str: str | bytes) -> "DodonaConfig":
         """Decode json string into a DodonaConfig object.
 
         Args:

--- a/judge/sql_database.py
+++ b/judge/sql_database.py
@@ -4,7 +4,6 @@ import os
 import sqlite3
 from shutil import copyfile
 from types import TracebackType
-from typing import Optional
 
 from .dodona_config import DodonaConfig
 from .sql_query import SQLQuery
@@ -55,7 +54,7 @@ class SQLDatabase:
 
         os.makedirs(os.path.dirname(self.solutionfile), exist_ok=True)
 
-        self.connection: Optional[sqlite3.Connection] = None
+        self.connection: sqlite3.Connection | None = None
 
     def __enter__(self) -> "SQLDatabase":
         """Create solutionfile and submissionfile.

--- a/judge/sql_query.py
+++ b/judge/sql_query.py
@@ -1,7 +1,6 @@
 """input query parsing."""
 
 import re
-from typing import Optional
 
 import sqlparse  # type: ignore
 
@@ -77,7 +76,7 @@ class SQLQuery:
         self.symbols = flatten_symbols(self.parsed)
         self.canonical = format_join_symbols(self.symbols)
 
-        self._is_ordered: Optional[bool] = None
+        self._is_ordered: bool | None = None
 
     @property
     def query_type(self) -> str:
@@ -134,7 +133,7 @@ class SQLQuery:
         mandatory_symbolregex: list[str],
         forbidden_fullregex: list[str],
         mandatory_fullregex: list[str],
-    ) -> Optional[tuple[Translator.Text, str]]:
+    ) -> tuple[Translator.Text, str] | None:
         """Check if query complies to all given regexs.
 
         Args:
@@ -170,7 +169,7 @@ class SQLQuery:
 
         return None
 
-    def first_match_regex(self, regex: str) -> Optional[str]:
+    def first_match_regex(self, regex: str) -> str | None:
         """Find the first symbol that matches the regex (case insensitive).
 
         Args:
@@ -187,7 +186,7 @@ class SQLQuery:
 
         return None
 
-    def first_match_array(self, words: list[str]) -> Optional[str]:
+    def first_match_array(self, words: list[str]) -> str | None:
         """Find the first symbol that occurs in the list of words.
 
         Args:

--- a/judge/sql_query_result.py
+++ b/judge/sql_query_result.py
@@ -117,6 +117,6 @@ class SQLQueryResult:
             string representation of all returned column names and their types
         """
         type_description = "\n".join(
-            f"{c} [{python_type_to_sqlite_type[t]}]" for (c, t) in zip(self.columns, self.types)
+            f"{c} [{python_type_to_sqlite_type[t]}]" for (c, t) in zip(self.columns, self.types, strict=True)
         )
         return type_description

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ extend-exclude = ["tests/e2e_repos"]
 target-version = "py312"
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "D", "C90", "I", "ERA", "PL", "RUF100"]
+select = ["E", "W", "F", "D", "C90", "I", "ERA", "PL", "RUF100", "UP", "B"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/sql_judge.py
+++ b/sql_judge.py
@@ -124,7 +124,7 @@ with Judgement():
         )
 
     # Parse solution query
-    with open(config.solution_sql, "r", encoding="utf-8") as sql_file:
+    with open(config.solution_sql, encoding="utf-8") as sql_file:
         config.raw_solution_file = sql_file.read()
         config.solution_queries = SQLQuery.from_raw_input(config.raw_solution_file)
 
@@ -137,7 +137,7 @@ with Judgement():
             )
 
     # Parse submission query
-    with open(config.source, "r", encoding="utf-8") as sql_file:
+    with open(config.source, encoding="utf-8") as sql_file:
         config.raw_submission_file = sql_file.read()
         config.submission_queries = SQLQuery.from_raw_input(config.raw_submission_file)
 


### PR DESCRIPTION
This PR enables some more ruff rules (pyupgrade and flake8-bugbear).

#206 deliberately left `UP` (pyupgrade) and `B` (flake8-bugbear) out of ruff's `select`, since those need actual source changes and that wasn't the job of the toolchain swap. This PR turns both on and fixes what they find. No runtime behaviour change anywhere, this is lint cleanup only.

<details>
#206 deliberately left `UP` (pyupgrade) and `B` (flake8-bugbear) out of ruff's `select`, since those need actual source changes and that wasn't the job of the toolchain swap. This PR turns both on and fixes what they find. No runtime behaviour change anywhere, this is lint cleanup only.

## What changed

**UP (pyupgrade), 16 findings, all in `judge/` and `sql_judge.py`:**

- 4x `UP042`: `ErrorType`, `MessagePermission`, `MessageFormat`, `AnnotationSeverity` in `judge/dodona_command.py` go from `class X(str, Enum)` to `class X(enum.StrEnum)`. Their `__str__` overrides (`return self`) are untouched, they're redundant now but that's not part of this rule's fix so I left them alone.
- 8x `UP045` + 2x `UP007`: `Optional[X]` -> `X | None`, `Union[X, Y]` -> `X | Y`, across `judge/dodona_command.py`, `judge/dodona_config.py`, `judge/sql_database.py`, `judge/sql_query.py`. `ruff --fix` also cleaned up the now-unused `Optional`/`Union` imports.
- 2x `UP015`: dropped the redundant `"r"` mode argument from the two `open(..., encoding="utf-8")` calls in `sql_judge.py`.

**B (flake8-bugbear), 2 findings:**

- `B024` in `judge/dodona_command.py`: `DodonaCommand(ABC)` has no abstract methods anywhere in the class (no `@abstractmethod` in the file at all), so `ABCMeta` was never actually blocking direct instantiation, it only does that once there's at least one abstract method. Dropped the `ABC` base (and the now-unused `from abc import ABC` import). Behaviourally inert.
- `B905` `zip()` without `strict=`. Only one non-test `zip()` call in the whole repo, `judge/sql_query_result.py:120`:
  ```python
  zip(self.columns, self.types)
  ```
  Went with **`strict=True`**. `SQLQueryResult.__init__` already asserts `len(dataframe.columns) == len(columns) == len(types)`, and the only other place that mutates `self.columns`/`self.types` (the reindexing method a few lines up) reassigns both from the same `argsort` index list in lockstep. So the two lists can never differ in length under correct usage, `strict=True` can't raise here, it just guards against a future regression reintroducing a mismatch.

No `# noqa` added anywhere, everything above is a genuine source fix.

<details>
<summary>Full finding list from <code>ruff check --extend-select UP,B .</code> before this PR (18 total)</summary>

```
judge/dodona_command.py:11:7: UP042 Class ErrorType inherits from both `str` and `enum.Enum`
judge/dodona_command.py:34:7: UP042 Class MessagePermission inherits from both `str` and `enum.Enum`
judge/dodona_command.py:50:7: UP042 Class MessageFormat inherits from both `str` and `enum.Enum`
judge/dodona_command.py:73:7: UP042 Class AnnotationSeverity inherits from both `str` and `enum.Enum`
judge/dodona_command.py:103:21: UP045 Use `X | None` for type annotations
judge/dodona_command.py:125:7: B024 `DodonaCommand` is an abstract base class, but it has no abstract methods or properties
judge/dodona_command.py:185:28: UP045 Use `X | None` for type annotations
judge/dodona_command.py:194:33: UP045 Use `X | None` for type annotations
judge/dodona_command.py:381:37: UP007 Use `X | Y` for type annotations
judge/dodona_config.py:64:56: UP007 Use `X | Y` for type annotations
judge/sql_database.py:58:26: UP045 Use `X | None` for type annotations
judge/sql_query.py:80:27: UP045 Use `X | None` for type annotations
judge/sql_query.py:137:10: UP045 Use `X | None` for type annotations
judge/sql_query.py:173:48: UP045 Use `X | None` for type annotations
judge/sql_query.py:190:54: UP045 Use `X | None` for type annotations
judge/sql_query_result.py:120:68: B905 `zip()` without an explicit `strict=` parameter
sql_judge.py:127:36: UP015 Unnecessary mode argument
sql_judge.py:140:30: UP015 Unnecessary mode argument
```

Numbers in the linked issue/PR description that mentioned "roughly 12 UP and 2 B" were rough, this is the actual full set (16 UP, 2 B).

</details>

</details>

## Verification

- `ruff check .` (UP and B now in `select`): `All checks passed!`
- `ruff format --check .`: no-op, 19 files already formatted
- `./devel/check.sh` (ruff check + format check + mypy): exits 0
- `pytest tests/ -q`: `76 passed`, both plain and with `-n auto`
- Ran the suite inside the actual production image (`ghcr.io/dodona-edu/dodona-sqlite:latest`, Python 3.12.9), since `UP` rules rewrite syntax in ways that can depend on Python version:
  ```
  docker run --rm -v "$PWD":/judge -w /judge --user root \
    ghcr.io/dodona-edu/dodona-sqlite:latest \
    sh -c 'apt-get update && apt-get install -y --no-install-recommends git \
           && git config --global --add safe.directory "*" \
           && ./devel/install_test_deps.sh && ./devel/run-tests.sh'
  ```
  `76 passed` there too.
- `tests/` untouched, `tests/e2e_stdout` goldens unchanged (checked `git status`/`git diff` on that path, both empty), so judge output is unchanged.
