### PR TITLE
Skip installing runtime dependencies in the lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,11 +15,8 @@ jobs:
           python-version: "3.12"
           cache: "pip"
           cache-dependency-path: |
-            requirements.txt
             requirements-dev.txt
             requirements-test.txt
-      - name: Install dependencies
-        run: ./devel/install_deps.sh
       - name: Install dev dependencies
         run: ./devel/install_dev_deps.sh
       - name: Run the linters


### PR DESCRIPTION
This PR skips installing runtime dependencies in the lint job. Came up during `ty` adoption, and this contains a lot more `ty` context below which I'll hide in a spoiler block. It basically means "if we were to switch to `ty`, we don't need these runtime deps either".

<details>


Stacked on #214 (drops the judge's last direct numpy import), which is itself stacked on #206 (ruff). Base branch here is `chore/drop-direct-numpy-use`.

## Outcome chosen: slim the lint job, keep mypy

`ty` (Astral's type checker) turned out not ready to replace mypy here. Details below.

## Baseline: mypy needs nothing installed

In a scratch venv with only `ruff==0.16.3` and `mypy==2.3.1` installed (no numpy, pandas, sqlparse), on top of #214:

```
mypy sql_judge.py judge/
Success: no issues found in 10 source files
```

`ruff check .` and `ruff format --check .` were already clean without those packages. So `.github/workflows/lint.yml`'s `./devel/install_deps.sh` step (which installs `requirements.txt`) does nothing useful for linting anymore. This PR drops that step and removes `requirements.txt` from `cache-dependency-path`. `devel/install_deps.sh` itself is untouched, it's still how a human sets up a local dev environment.

## ty evaluation

Installed `pip install ty` -> got `ty 0.0.72` (beta, matches what's on PyPI).

**Does it run at all?** Yes.

**Does it need the runtime deps installed?** No, once its Python environment is pinned correctly. Worth flagging: without `--python <venv>`, ty silently resolved imports against an unrelated global Python install on this machine instead of the venv it was invoked from, which would make its behaviour depend on the CI runner's ambient Python state rather than only what's installed for the job. Pinned with `--python`, it's clean of import errors on the same no-numpy/pandas/sqlparse setup mypy uses.

**Does it report anything mypy doesn't?** Yes, 18 diagnostics against a codebase mypy considers 100% clean:

- 17x `invalid-context-manager`, one for every `with` block using `DodonaCommand` subclasses (`Judgement`, `Tab`, `Context`, `TestCase`, `Test`, `Message`, `Annotation`) and `SQLDatabase`. Root cause: those classes type `__exit__`'s `exc_type`/`exc_val`/`exc_tb` params as non-`Optional`, but Python calls `__exit__(None, None, None)` when no exception occurred, so the signature is technically imprecise. Confirmed with a minimal repro outside the codebase: a class with a non-Optional `__exit__` fails, the same class with `Optional[...]` params passes. Not a runtime bug (mypy doesn't enforce this and nothing in the `__exit__` bodies assumes non-None), but it means adopting ty as-is would require rewriting every `__exit__` signature in the codebase just to get the lint job green again, that's a real source change, not a config change.
- 1x `invalid-argument-type` in `judge/sql_query_result.py:120`: `python_type_to_sqlite_type[t]` where the dict's inferred key type (a narrow union of `type[None]|type[int]|type[float]|type[str]|type[bytes]`) doesn't structurally match the declared `types: list[type]` parameter. In practice `from_cursor` only ever produces exactly those five types from sqlite3 cursor values, so this isn't an active bug, but it is a real (if harmless) gap between the declared and actual type.

**Does it miss anything mypy catches?** Tested concretely: reintroduced the implicit-Optional bug in `judge/dodona_command.py` (`recover_at: type = None` instead of `Optional[type]`), then reverted.

- mypy: `error: Incompatible default for parameter "recover_at" (default has type "None", parameter has type "type") [assignment]` plus 4 follow-on `has-type` errors.
- ty: `error[invalid-parameter-default]: Default value of type None is not assignable to annotated parameter type type`.

Both catch it, so no coverage is lost on this specific bug class.

**Verdict:** ty is pre-1.0 and, on this codebase, clearing its findings needs real source changes (13+ `__exit__` signatures), not just a tooling swap. Given the maintainer explicitly left "not yet" on the table, keeping mypy is the safer call for now. The numbers above are recorded here so this is easy to revisit once ty is further along.

## CI simulation

Faithfully simulated the updated lint job: fresh venv, install only what the new `lint.yml` installs, run the linters.

```
python3.12 -m venv venv-ci-sim
venv-ci-sim/bin/pip install -r requirements-dev.txt   # pulls in requirements-test.txt too
venv-ci-sim/bin/pip list
# ast_serialize, coverage, execnet, iniconfig, librt, mypy, mypy_extensions,
# packaging, pathspec, pluggy, Pygments, pytest, pytest-cov, pytest-xdist,
# ruff, typing_extensions -- no numpy/pandas/sqlparse

PATH=venv-ci-sim/bin:$PATH ./devel/check.sh
All checks passed!
19 files already formatted
Success: no issues found in 10 source files
```

## Other verification

- `PATH=<provided ruff+mypy venv>/bin:$PATH ./devel/check.sh` -> exit 0.
- `git submodule update --init`, then `pytest tests/ -q` -> `76 passed`, and `-n auto` -> `76 passed`.
- `git status --short tests/e2e_stdout` clean.
- `ruff format .` is a no-op.

## Diff

Just `.github/workflows/lint.yml`: drop the `Install dependencies` step (`./devel/install_deps.sh`) and drop `requirements.txt` from `cache-dependency-path`.

</details>