### PR TITLE
Fix __exit__ annotations flagged by ruff PYI036

### DIFF
--- a/judge/dodona_command.py
+++ b/judge/dodona_command.py
@@ -256,9 +256,9 @@ class DodonaCommand(ABC):
 
     def __exit__(
         self,
-        exc_type: type[BaseException],
-        exc_val: BaseException,
-        exc_tb: TracebackType,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> bool:
         """Print the close message when exiting the 'with' block & handle enclosed exceptions.
 

--- a/judge/sql_database.py
+++ b/judge/sql_database.py
@@ -75,9 +75,9 @@ class SQLDatabase:
 
     def __exit__(
         self,
-        exc_type: type[BaseException],
-        exc_val: BaseException,
-        exc_tb: TracebackType,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> None:
         """Commit & close current database connection on exit.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ extend-exclude = ["tests/e2e_repos"]
 target-version = "py312"
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "D", "C90", "I", "ERA", "PL", "RUF"]
+select = ["E", "W", "F", "D", "C90", "I", "ERA", "PL", "RUF", "PYI036"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
This PR adds `PYI036` to the ruff list of things to check for. It used to flag on wrongly typed `__exit__` calls since they were missing `Optional`. Since we call exit without types on the non-exception path, this was wrongly typed before.

<details>

## The fix

`ruff check --select PYI036 .` flags 6 findings: the 3 parameters of `DodonaCommand.__exit__` (`judge/dodona_command.py`) and the 3 parameters of `SQLDatabase.__exit__` (`judge/sql_database.py`) are all annotated as non-`Optional`, but Python calls `__exit__(None, None, None)` on the normal, non-exception exit path, so the old annotations were simply untrue. Fixed with `type[BaseException] | None` / `BaseException | None` / `TracebackType | None`, matching ruff's suggested fix.

Checked both bodies handle `None` fine already (they have to, that path runs on every successful `with` block):
- `dodona_command.py`: `isinstance(exc_val, DodonaException)` is `False` when `exc_val` is `None`, falls through to the non-exception branch.
- `sql_database.py`: ignores all three arguments and just calls `self.close()`.

So this is annotation-only, no behaviour change.

Adds `"PYI036"` to `select` in `[tool.ruff.lint]` so it stays fixed. Didn't add the whole `PYI` group: it's not clean after this fix (`PYI034` flags `SQLDatabase.__enter__`'s return type, `-> "SQLDatabase"` instead of `Self`), and that's a separate change I didn't want to bundle in here.

## What this means for #217

#217 declined to swap mypy for `ty` because `ty` reported 18 diagnostics mypy doesn't: 17 `invalid-context-manager` (one per `with` block over a `DodonaCommand` subclass or `SQLDatabase`) plus 1 unrelated `invalid-argument-type`. All 17 trace back to exactly this annotation bug. So the question was: does fixing PYI036 make `ty` go quiet?

Reran the same experiment, `ty 0.0.72`, pinned with `--python` at the venv that has this repo's runtime deps installed (same setup #217 used, `--python` matters, without it `ty` silently resolves some other Python's site-packages):

- **Before**: 20 diagnostics, 17 `invalid-context-manager` + 1 `invalid-argument-type` + 2 `unused-type-ignore-comment` warnings (on the `sqlparse`/`pandas` imports, `mypy` doesn't flag these since `warn_unused_ignores` isn't on).
- **After**: 3 diagnostics, same `invalid-argument-type` error and same 2 warnings, zero `invalid-context-manager`.

So yes, all 17 `invalid-context-manager` errors are gone and nothing else moved. #217's "not yet" was really "our annotations are wrong". The 3 that remain are pre-existing and unrelated to `__exit__`, so `ty` isn't fully quiet, but its signal here is now much smaller and arguably worth revisiting, even though this PR doesn't adopt it (that's still a bigger call than an annotation fix).

## Verification

- `PATH=<ruff+mypy venv>/bin:$PATH ./devel/check.sh` passes (ran the 3 steps individually, same result): `ruff check .`, `ruff format --check .`, `mypy sql_judge.py judge/` all clean.
- `git submodule update --init`, then `pytest tests/ -q` -> `76 passed`, and `-n auto` -> `76 passed`.
- `git status --short tests/e2e_stdout` clean, no golden drift.
- Ran the suite inside `ghcr.io/dodona-edu/dodona-sqlite:latest` (production image) -> `76 passed`.
- `ruff format .` is a no-op.

<details>
<summary>ty output, before and after</summary>

Before (main, `afb2992`'s parent):
```
error[invalid-context-manager]: Object of type `Message` cannot be used with `with` because it does not correctly implement `__exit__`
   --> judge/dodona_command.py:239:18
... (17 total, one per with block over a DodonaCommand subclass / SQLDatabase)

error[invalid-argument-type]: Method `__getitem__` of type `bound method dict[...]` cannot be called with key of type `type`
   --> judge/sql_query_result.py:120:21

warning[unused-type-ignore-comment]: Unused blanket `type: ignore` directive
 --> judge/sql_query.py:6:18
warning[unused-type-ignore-comment]: Unused blanket `type: ignore` directive
 --> judge/sql_query_result.py:6:22

Found 20 diagnostics
```

After (this branch):
```
warning[unused-type-ignore-comment]: Unused blanket `type: ignore` directive
 --> judge/sql_query.py:6:18
warning[unused-type-ignore-comment]: Unused blanket `type: ignore` directive
 --> judge/sql_query_result.py:6:22

error[invalid-argument-type]: Method `__getitem__` of type `bound method dict[...]` cannot be called with key of type `type`
   --> judge/sql_query_result.py:120:21

Found 3 diagnostics
```
</details>
</details>
