### PR TITLE
Swap mypy for ty

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
       linters:
         patterns:
           - "ruff"
-          - "mypy"
+          - "ty"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/devel/check.sh
+++ b/devel/check.sh
@@ -7,8 +7,6 @@ cd "$ROOT"
 
 ruff check .
 ruff format --check .
-# --python is required: without it, ty falls back to whatever python3 happens to be first on
-# PATH, which on a dev machine with several interpreters installed (pyenv/mise/asdf, ...) is not
-# reliably the one requirements-dev.txt was installed into, and ty then silently type-checks
-# against the wrong site-packages. Resolving it explicitly here keeps local runs and CI identical.
+# --python is required: CI has no .venv and no activated venv, so without
+# it ty resolves based on what's available, which varies by machine.
 ty check --python "$(command -v python3)" sql_judge.py judge/

--- a/devel/check.sh
+++ b/devel/check.sh
@@ -7,4 +7,8 @@ cd "$ROOT"
 
 ruff check .
 ruff format --check .
-mypy sql_judge.py judge/
+# --python is required: without it, ty falls back to whatever python3 happens to be first on
+# PATH, which on a dev machine with several interpreters installed (pyenv/mise/asdf, ...) is not
+# reliably the one requirements-dev.txt was installed into, and ty then silently type-checks
+# against the wrong site-packages. Resolving it explicitly here keeps local runs and CI identical.
+ty check --python "$(command -v python3)" sql_judge.py judge/

--- a/judge/sql_query_result.py
+++ b/judge/sql_query_result.py
@@ -7,7 +7,12 @@ import pandas as pd  # type: ignore
 
 NoneType = type(None)
 
-python_type_to_sqlite_type = {
+# The only column types 'from_cursor' can ever produce, since sqlite3 only maps rows to these five
+# Python types. Spelled out explicitly (instead of the broader 'type') so the type checker can verify
+# that every access into 'python_type_to_sqlite_type' below is exhaustive.
+SqliteColumnType = type[None] | type[int] | type[float] | type[str] | type[bytes]
+
+python_type_to_sqlite_type: dict[SqliteColumnType, str] = {
     NoneType: "NULL",
     int: "INTEGER",
     float: "REAL",
@@ -19,7 +24,7 @@ python_type_to_sqlite_type = {
 class SQLQueryResult:
     """a class for managing a query's results."""
 
-    def __init__(self, dataframe: pd.DataFrame, columns: list[str], types: list[type]) -> None:
+    def __init__(self, dataframe: pd.DataFrame, columns: list[str], types: list[SqliteColumnType]) -> None:
         """Create new SQLQueryResult.
 
         Should not be used directly (other than testing). Use 'from_cursor' instead.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements-test.txt
 
 ruff==0.16.3
-mypy==2.3.1
+ty==0.0.72


### PR DESCRIPTION
Replaces mypy with `ty` (Astral's type checker), so the repo runs one fast toolchain (ruff + ty) instead of two.

<details>

## Background

#217 declined this swap because ty reported 20 diagnostics, 17 of them `invalid-context-manager` caused by `__exit__` methods annotating `exc_type`/`exc_val`/`exc_tb` as non-optional, which isn't true on the normal exit path. #219 fixed that.

Since #217, the lint job also installs only `requirements-dev.txt` (no pandas/numpy/sqlparse). Measured under that exact condition (fresh venv, only `requirements-dev.txt`), ty 0.0.72 reports a single diagnostic:

- `invalid-argument-type` at `judge/sql_query_result.py:120`: indexing `python_type_to_sqlite_type` (whose inferred key type is a union of the five literal classes used in the dict literal) with a value typed as the broad `type`. Fixed by narrowing `types: list[type]` to a `SqliteColumnType` type alias (`type[None] | type[int] | type[float] | type[str] | type[bytes]`) that matches exactly what `from_cursor` can ever produce, and typing the dict as `dict[SqliteColumnType, str]`. No suppression needed.

Measuring again with the runtime deps installed too (mirroring what #217 originally saw) additionally surfaces 2 `unused-type-ignore-comment` warnings on the `pandas` and `sqlparse` imports. Those ignores are **not** removable though: under the real CI condition (deps absent) removing them turns into 2 `unresolved-import` errors instead, since ty checks against whatever `--python` environment it's given, and pandas/sqlparse genuinely aren't importable there. Left them in place. This asymmetry is inherent to the runtime deps being optional at lint time, not something to fix via `[tool.ty.rules]`.

## The `--python` flag

`devel/check.sh` now passes `ty check --python "$(command -v python3)" ...`. Without `--python`, ty falls back to whatever `python3` happens to resolve first on `PATH`, which on a dev machine with several interpreters installed (mise/pyenv/asdf, ...) is not reliably the one `requirements-dev.txt` was installed into. Verified this concretely: without `--python`, ty on this machine picked up an unrelated interpreter that happened to have pandas installed but not sqlparse, silently producing a different (and wrong) diagnostic set. `$(command -v python3)` resolves to whatever interpreter `pip3` installed the dev deps into, in both local dev and CI (`actions/setup-python` puts a single interpreter on `PATH`, no venv).

## Coverage check

mypy earned its place catching an implicit-`Optional`. Confirmed ty doesn't lose that:

- Reintroducing `recover_at: type = None` (implicit-Optional) in `judge/dodona_command.py`: ty flags `invalid-parameter-default: Default value of type 'None' is not assignable to annotated parameter type 'type'`. Reverted, `git status --short` clean.
- Dropping the `| None` from one `__exit__`'s `exc_type` annotation in `judge/sql_database.py` (the #219 fix): ty flags 2x `invalid-context-manager`, the exact class of bug that blocked #217. Reverted, `git status --short` clean.

## Verification

<details>
<summary>1. <code>./devel/check.sh</code> in a CI-condition venv (Python 3.12, only <code>requirements-dev.txt</code>)</summary>

```
mise exec python@3.12 -- python3 -m venv /tmp/final-verify
/tmp/final-verify/bin/pip install --upgrade pip -q
/tmp/final-verify/bin/pip install -r requirements-dev.txt -q
PATH="/tmp/final-verify/bin:$PATH" ./devel/check.sh
```

```
All checks passed!
19 files already formatted
All checks passed!
```
</details>

<details>
<summary>2. pytest (serial and <code>-n auto</code>), 76 passed both ways</summary>

```
git submodule update --init
python3 -m venv /tmp/final-test
/tmp/final-test/bin/pip install -r requirements.txt -r requirements-test.txt -q
/tmp/final-test/bin/pytest tests/ -q          # 76 passed
/tmp/final-test/bin/pytest tests/ -q -n auto  # 76 passed
```

`git status --short tests/e2e_stdout` clean.
</details>

<details>
<summary>3. Production image suite</summary>

```
docker run --rm -v "$PWD":/judge -w /judge --user root \
  ghcr.io/dodona-edu/dodona-sqlite:latest \
  sh -c 'apt-get update && apt-get install -y --no-install-recommends git \
         && git config --global --add safe.directory "*" \
         && ./devel/install_test_deps.sh && ./devel/run-tests.sh'
```

`76 passed`.
</details>

`ruff check .` and `ruff format --check .` clean.

## Note

ty is `0.0.72` and pre-1.0. A Dependabot bump could plausibly change its behaviour (new diagnostics, changed inference), so those bumps should be reviewed rather than rubber-stamped, unlike the ruff bumps we've been merging pretty freely.

</details>