### PR TITLE
Replace LGTM badge with CodeQL badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [![GitHub branch](https://img.shields.io/github/checks-status/dodona-edu/judge-sql/main)](https://github.com/dodona-edu/judge-sql/actions?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/dodona-edu/judge-sql/branch/main/graph/badge.svg?token=yqUL5ee6tA)](https://codecov.io/gh/dodona-edu/judge-sql)
-[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/dodona-edu/judge-sql.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/dodona-edu/judge-sql/context:python)
+[![CodeQL](https://github.com/dodona-edu/judge-sql/actions/workflows/codeql.yml/badge.svg)](https://github.com/dodona-edu/judge-sql/actions/workflows/codeql.yml)
 [![Python 3.12](https://img.shields.io/badge/python-3.12-green.svg)](https://www.python.org/downloads/release/python-3129/)
 
 ## Judge features


### PR DESCRIPTION
The LGTM.com badge has been replaced with the CodeQL workflow badge. LGTM.com was shut down by GitHub and its CodeQL engine was folded into GitHub code scanning, making the old badge link a 404.

CodeQL is the direct successor and already runs on this repo via `.github/workflows/codeql.yml`. Note that PR #174 proposes removing the CodeQL workflow entirely, so if that is ever merged this badge should go with it.
