### PR TITLE
Move pip dependency updates to monthly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: pip
     directory: "/"
     schedule:
-      interval: weekly
-      day: monday
+      interval: monthly
       time: "04:00"
       timezone: Europe/Brussels
     open-pull-requests-limit: 99


### PR DESCRIPTION
This PR moves pip dep updates to a monthly schedule.

<details>
Pip dependency updates now run monthly instead of weekly to cut down on the volume of automated dependency PRs. The `day: monday` configuration has been removed as it only applies to weekly schedules.

The `github-actions` ecosystem remains on a weekly schedule.

A similar dependabot refresh is being prepared for `dodona-edu/judge-html` in PR #261.
</details>