### PR TITLE
Align the tooling with judge-html and judge-turtle

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,8 +15,14 @@ jobs:
           python-version: "3.12"
           cache: "pip"
           cache-dependency-path: |
+            requirements.txt
             requirements-dev.txt
             requirements-test.txt
+      # ty has to be able to import pandas and sqlparse to resolve them. Without the runtime deps it
+      # reports unresolved-import, and silently types everything they return as Unknown, so the
+      # type check stops checking.
+      - name: Install dependencies
+        run: ./devel/install_deps.sh
       - name: Install dev dependencies
         run: ./devel/install_dev_deps.sh
       - name: Run the linters

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,3 @@
-python 3.12
+# Must match the base image pinned in dodona-edu/docker-images/dodona-sqlite.dockerfile,
+# so local development runs exactly the interpreter production runs. Bump the two together.
+python 3.12.9

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,10 @@
+# No comment on the pull request: the numbers still show up as checks, and a bot
+# comment on every PR is just noise.
+comment: false
+
+coverage:
+  round: down
+  precision: 5
+
+ignore:
+  - "./tests/*"

--- a/judge/sql_query.py
+++ b/judge/sql_query.py
@@ -2,7 +2,7 @@
 
 import re
 
-import sqlparse  # ty: ignore[unresolved-import]
+import sqlparse
 
 from .translator import Translator
 

--- a/judge/sql_query_result.py
+++ b/judge/sql_query_result.py
@@ -3,7 +3,7 @@
 import io
 from sqlite3 import Cursor
 
-import pandas as pd  # ty: ignore[unresolved-import]
+import pandas as pd
 
 NoneType = type(None)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
-# Transitive pin, not a direct dependency: pandas 2.1.1 is built against numpy 1.x, so an unpinned install pulls numpy 2.x and fails at import with "ValueError: numpy.dtype size changed".
-numpy==1.26.4
+# These mirror dodona-edu/docker-images/dodona-sqlite.dockerfile: the judge runs with
+# whatever that image ships, so a pin that differs from it is a lie about production.
 pandas==2.1.1
-sqlparse==0.6.0
+# Nothing in the judge imports numpy, but the image installs it alongside pandas on purpose:
+# pandas 2.1.1 is built against numpy 1.x, so an unpinned install pulls numpy 2.x and fails at
+# import with "ValueError: numpy.dtype size changed".
+numpy==1.26.4
+sqlparse==0.4.4


### PR DESCRIPTION
Last round before we start thinking about the dependabot updates. This PR closes some gaps between the tooling compares to the html and turtle judge:

- `requirements.txt` had drifted from the judge image
- the dev pipeline didn't load the requirements, meaning that those imports couldn't be type checked. It now does
- codecov was lacking here, added it

<details>

Closes the tooling gaps judge-sql still had against judge-html and judge-turtle.

### requirements.txt matches the image again

`requirements.txt` documents what `ghcr.io/dodona-edu/dodona-sqlite` ships, and
production installs from the image, not from the file, so drift here is a lie
about what runs rather than a version anybody gets. sqlparse had drifted to
0.6.0 through #211, a Dependabot bump the dockerfile never followed, so it goes
back to 0.4.4. Deliberately matching production instead of bumping the image:
that keeps a clear baseline to iterate on later. Note the integration test runs
inside the image, so it has been exercising 0.4.4 the whole time anyway.

Dependabot will re-propose the 0.6.0 bump next month. An allow-list to stop that
is a separate call, so it is not in here.

`.tool-versions` picks up the base image's full patch version (3.12.9) for the
same reason a bare `3.12` was not enough.

### Real type coverage on pandas

The lint job never installed the runtime dependencies, so ty could not resolve
pandas or sqlparse, and the two `# ty: ignore[unresolved-import]` comments papered
over that. An unresolved module is Unknown and so is everything it returns, so
`sql_query.py` and `sql_query_result.py` were effectively unchecked.

Two things I did not expect going in:

- pandas ships no `py.typed`, but ty reads its source anyway and its inline
  annotations are good, so `DataFrame`, `Index` and friends now carry real types.
  I did not add `pandas-stubs`, since ty already resolves pandas without it.
- sqlparse only gained `py.typed` in 0.6.0, and there is no stub package for
  0.4.4 anywhere (no `types-sqlparse` on PyPI, nothing in typeshed). So
  `sql_query.py` still sees Unknown from sqlparse, and there is nothing to add
  to `requirements-dev.txt` for it. That half arrives when the image bumps.

No type errors fell out of any of this, so there is no fix-up commit. I checked
that is real coverage and not a silent no-op, output below.

### codecov.yaml

Copied from judge-html, so the bot stops commenting on every PR.

Out of scope on purpose: CodeQL, a Dependabot allow-list, and the ruff ignore
list in `pyproject.toml`.

</details>

### Testing

Nothing user-visible changes, so this is a "does the toolchain still work" pass:

1. `mise install` (the pin moved to 3.12.9, so it needs fetching)
2. `mise exec -- ./devel/install_deps.sh && mise exec -- ./devel/install_dev_deps.sh`
3. `mise exec -- ./devel/check.sh` should pass with no ty diagnostics
4. `mise exec -- ./devel/run-tests.sh` should pass on sqlparse 0.4.4
5. On CI, the lint job should now show an "Install dependencies" step, and
   codecov should not comment on this PR

<details>
<summary>Local verification output</summary>

`./devel/check.sh`:

```
All checks passed!
19 files already formatted
All checks passed!
```

`./devel/run-tests.sh`:

```
platform darwin -- Python 3.12.9, pytest-9.1.1, pluggy-1.6.0
12 workers [76 items]
============================== 76 passed in 3.23s ==============================
```

Proof the runtime-dependency install is what does the work, pointing ty at a
venv without them:

```
$ ty check --python /tmp/nodeps-venv/bin/python3 sql_judge.py judge/
judge/sql_query.py:5:8: error[unresolved-import] Cannot resolve imported module `sqlparse`
judge/sql_query_result.py:6:8: error[unresolved-import] Cannot resolve imported module `pandas`
Found 2 diagnostics
```

And proof that pandas resolves to something useful rather than Unknown, from a
scratch `reveal_type` on the real attribute:

```
judge/sql_query_result.py:131:17: info[revealed-type] Revealed type: `DataFrame`
judge/sql_query_result.py:132:17: info[revealed-type] Revealed type: `Index`
```

The same probe on sqlparse reveals `Unknown` for `parse`, `split`, `format` and
every `Statement` member, which is the 0.6.0 gap above.

</details>
